### PR TITLE
Rename package to opencode-sdd-engram-manage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ If the file doesn't exist, create it at:
 `~/.config/opencode/tui.json`
 
 ### Content
-Add `"model-selection-plugin"` to the `plugin` array:
+Add `"opencode-sdd-engram-manage"` to the `plugin` array:
 
 ```json
 {
    "$schema": "https://opencode.ai/tui.json",
-   "plugin": ["model-selection-plugin"]
+   "plugin": ["opencode-sdd-engram-manage"]
 }
 ```
 
@@ -40,7 +40,7 @@ Add `"model-selection-plugin"` to the `plugin` array:
 
 ## Technical Details
 
-- **Name:** `model-selection-plugin`
+- **Name:** `opencode-sdd-engram-manage`
 - **Engines:** Requires `opencode >= 1.3.13`
 - **Peer Dependencies:** `@opencode-ai/plugin`, `@opentui/core`, `@opentui/solid`, `solid-js`.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "model-selection-plugin",
+  "name": "opencode-sdd-engram-manage",
   "version": "1.0.0",
   "description": "Interactive SDD model selection and profile management for opencode",
   "type": "module",


### PR DESCRIPTION
## Summary
Renaming the package to a more descriptive name: `opencode-sdd-engram-manage`.

## Changes
- Updated `package.json` name field.
- Updated `README.md` installation instructions.

This PR will trigger the publication of the package under the new name upon merge.