### PR TITLE
ci: publish npm package on main push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,21 +1,44 @@
 name: Publish to NPM
+
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
-      - main # Cambiado de master a main
+      - main
+  workflow_dispatch:
 
 jobs:
   publish:
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
+
       - run: npm ci
-      - run: npm publish --access public
+
+      - name: Resolve package metadata
+        id: pkg
+        run: |
+          echo "name=$(node -p \"require('./package.json').name\")" >> "$GITHUB_OUTPUT"
+          echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+
+      - name: Check if version already exists on npm
+        id: npm_check
+        run: |
+          if npm view "${{ steps.pkg.outputs.name }}@${{ steps.pkg.outputs.version }}" version >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Version already published, skipping npm publish."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Version not published yet, proceeding."
+          fi
+
+      - name: Publish package
+        if: steps.npm_check.outputs.exists == 'false'
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- switch publish workflow trigger from closed PR events to push on `main`
- remove label-based gate so publish does not depend on manual `release` labeling
- add idempotent npm version check to skip publish when the version already exists

## Why
The previous workflow was skipped unless merged PRs had the `release` label. This blocked expected automatic publishing after merge.

## Verification
- workflow syntax updated and committed in `.github/workflows/publish.yml`
- publish step now executes only when package version is not already published
