### PR TITLE
fix(ci): repair publish workflow metadata extraction

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,7 @@ jobs:
       - name: Resolve package metadata
         id: pkg
         run: |
-          echo "name=$(node -p \"require('./package.json').name\")" >> "$GITHUB_OUTPUT"
-          echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+          node -e "const p=require('./package.json'); console.log('name=' + p.name); console.log('version=' + p.version);" >> "$GITHUB_OUTPUT"
 
       - name: Check if version already exists on npm
         id: npm_check


### PR DESCRIPTION
## Summary
- fix publish workflow metadata step that failed with a bash syntax error
- avoid command substitution with nested quotes and resolve package metadata via a single Node script

## Root Cause
The previous workflow used nested command substitution in bash for `name` and `version`, which produced a syntax error in the runner shell.

## Verification
- publish workflow now writes both outputs (`name`, `version`) using a single `node -e` execution
