### PR TITLE
chore(release): publish v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "model-selection-plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "model-selection-plugin",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "engines": {
         "opencode": ">=1.3.13"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-sdd-engram-manage",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Interactive SDD model selection and profile management for opencode",
   "type": "module",
   "main": "index.tsx",


### PR DESCRIPTION
## Summary
- bump package version from `1.0.0` to `1.1.0` for the new fallback feature release
- keep changes limited to release metadata (`package.json` and lockfile)

## Why
The fallback feature set is additive (no breaking changes), so semver minor bump is required.

## Verification
- `package.json` version updated to `1.1.0`
- `package-lock.json` root version aligned to `1.1.0`
