### PR TITLE
fix(dialogs): scope profile detail to profile agents

### DIFF
--- a/src/dialogs.tsx
+++ b/src/dialogs.tsx
@@ -329,9 +329,12 @@ export function showProfileDetail(api: any, profileOpt: any) {
     const profilePath = path.join(profilesDir, profileOpt.value);
     const profileData = readProfileData(profilePath);
     const configAgents = api.state.config?.agent || {};
-    const sddAgentNames = Object.keys(configAgents)
-      .filter(isPrimarySddAgent)
-      .sort();
+    const profileAgentNames = Object.keys(profileData.models || {}).sort();
+    const sddAgentNames = profileAgentNames.length > 0
+      ? profileAgentNames
+      : Object.keys(configAgents)
+          .filter(isPrimarySddAgent)
+          .sort();
 
     const sddAgents = sddAgentNames.map((name) => [name, profileData.models?.[name]] as [string, string | undefined]);
     const fallbackModelMap = profileData.fallback || {};


### PR DESCRIPTION
Closes #12

## Summary
- render profile detail rows from the selected profile keys instead of every active `sdd-*` agent
- keep the existing config-derived fallback only for empty profiles so brand new profiles remain editable
- remove misleading `Unassigned` noise when using suffix-based profiles like `cheap`

## Changes
| File | Change |
|------|--------|
| `src/dialogs.tsx` | Prefer `profileData.models` keys in `showProfileDetail()` and fall back to config agents only when the profile is empty |

## Test Plan
- [x] `npm test`
- [x] `npm run build`
- [x] Manually verified local OpenCode TUI now shows only `*-cheap` rows for `cheap.json`
