### PR TITLE
feat: add profile bulk actions and version history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - feat/**
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,6 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Build package
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 *.tgz
 examples/.tmp-run
+.atl

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Manage [SDD (Spec-Driven Development)](https://github.com/Gentleman-Programming/
 - **Create:** Create an empty SDD profile for manual configuration.
 - **Activate:** Apply a saved profile to the global runtime config instantly — no restart required. Changes are live immediately.
 - **Edit Models:** Pick a different provider/model for any agent or fallback directly from the UI.
+- **Bulk Actions:** Use **Bulk actions...** to assign primary models, fallback models, or both across the whole profile.
+- **Profile Versions:** Use **Profile versions...** to preview and restore saved snapshots before risky changes.
 - **Rename & Delete:** Full lifecycle management for your profiles.
 - **Per-Agent Fallbacks:** Configure a fallback model per `sdd-*` base agent (except `sdd-orchestrator`). On activation, the plugin ensures `sdd-*-fallback` agents exist and stay in sync with their base agent config. Primary models are applied first, so you can define new agents and their fallbacks in a single profile activation.
 - **Active Profile Detection:** The plugin automatically detects and highlights which profile matches the current config.
@@ -35,6 +37,8 @@ Profiles are stored as JSON files under `~/.config/opencode/profiles/`:
 
 - `models`: primary model per base `sdd-*` agent.
 - `fallback`: optional fallback model override per base agent name. If omitted, the fallback agent inherits the base model.
+
+Profile versions are stored separately under `~/.config/opencode/profile-versions/`, or `$XDG_CONFIG_HOME/opencode/profile-versions/` when `XDG_CONFIG_HOME` is set. Version metadata is not written into the main profile JSON file, so profile files stay portable and focused on runtime model configuration.
 
 Legacy flat format is also supported for backwards compatibility:
 
@@ -87,7 +91,38 @@ Open the plugin with:
 2. **Create a profile** for your project, or **Manage Profiles** to activate/configure one.
 3. From the profile detail, click any agent to change its model (provider → model picker).
 4. Click any fallback entry to override its model.
-5. **Activate** to apply the profile to the live runtime.
+5. Use **Bulk actions...** when you want to configure many agents at once.
+6. Use **Profile versions...** to preview or restore previous snapshots.
+7. **Activate** to apply the profile to the live runtime.
+
+### Bulk Profile Actions
+
+From a profile detail screen, **Bulk actions...** lets you apply one model selection to many phase entries:
+
+- **Set all primary phases:** fill missing primary phase models only.
+- **Set all fallback phases:** fill missing fallback phase models only.
+- **Set all phases and fallbacks:** fill missing primary and fallback phase models.
+- **Override all primary phases:** replace every primary phase model after confirmation.
+- **Override all fallback phases:** replace every fallback phase model after confirmation.
+- **Override all phases and fallbacks:** replace every primary and fallback phase model after confirmation.
+
+The difference is intentional:
+
+- **Set** actions are fill-only. They keep existing values and only populate empty entries.
+- **Override** actions are overwrite operations. They can replace existing choices, so the UI asks for confirmation before applying them.
+
+Before any bulk operation is applied, the plugin saves a profile version automatically.
+
+### Profile Versions
+
+Use **Profile versions...** from the profile detail screen to review saved profile snapshots.
+
+- Versions are created automatically before bulk profile actions.
+- Versions are also created automatically before individual primary or fallback phase model changes.
+- Each version can be previewed before restoring it.
+- Restore writes the selected snapshot back to the profile file.
+
+Version history is stored outside the profile JSON under `~/.config/opencode/profile-versions/`, or `$XDG_CONFIG_HOME/opencode/profile-versions/` when configured. The profile JSON itself only contains model data (`models` and `fallback`); version metadata is kept out of the main profile file.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,57 @@ Safety: Profile versions... → preview the saved snapshot → restore if the bu
 
 Before any bulk operation is applied, the plugin saves a profile version automatically.
 
+#### Compact text screenshots
+
+These compact mockups show the new profile flows without relying on image assets:
+
+```text
+Profile: team-default                         active
+──────────────────────────────────────────────────
+Primary phases
+  sdd-spec      anthropic/claude-sonnet-4-6
+  sdd-apply     openai/gpt-5.5
+
+Fallback phases
+  sdd-spec      google/gemini-flash-2.0
+  sdd-apply     inherited from primary
+
+[Activate]  [Edit JSON]  [Bulk actions...]  [Profile versions...]
+```
+
+```text
+Bulk actions
+──────────────────────────────────────────────────
+Set
+  Set all primary phases
+  Set all fallback phases
+  Set all phases and fallbacks
+
+Override
+  Override all primary phases        requires confirmation
+  Override all fallback phases       requires confirmation
+  Override all phases and fallbacks  requires confirmation
+```
+
+```text
+Profile versions: team-default
+──────────────────────────────────────────────────
+When                  Bulk                         Phase
+2026-04-26 14:08      Set all fallback phases      all fallback phases
+2026-04-26 13:52      Override all primary phases  all primary phases
+2026-04-26 13:10      Manual edit                  sdd-apply
+```
+
+```text
+Preview version 2026-04-26 14:08
+──────────────────────────────────────────────────
+models.sdd-apply      openai/gpt-5.5
+fallback.sdd-apply    google/gemini-flash-2.0
+
+[Restore this version]  [Back]
+Restore? This replaces the current profile file.
+```
+
 ### Profile Versions
 
 Use **Profile versions...** from the profile detail screen to review saved profile snapshots.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ The difference is intentional:
 - **Set** actions are fill-only. They keep existing values and only populate empty entries.
 - **Override** actions are overwrite operations. They can replace existing choices, so the UI asks for confirmation before applying them.
 
+Compact flow example:
+
+```text
+Before: profile has mixed primary models and missing fallbacks.
+Bulk action: Set all fallback phases → google/gemini-flash-2.0.
+After: existing primary models stay untouched; empty fallbacks are filled.
+Safety: Profile versions... → preview the saved snapshot → restore if the bulk change was not what you wanted.
+```
+
 Before any bulk operation is applied, the plugin saves a profile version automatically.
 
 ### Profile Versions

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Use **Profile versions...** from the profile detail screen to review saved profi
 
 - Versions are created automatically before bulk profile actions.
 - Versions are also created automatically before individual primary or fallback phase model changes.
+- Profile versions use one unified history for bulk actions and individual phase changes, retaining the latest 60 snapshots per profile.
 - Each version can be previewed before restoring it.
 - Restore writes the selected snapshot back to the profile file.
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Fallback phases
   sdd-spec      google/gemini-flash-2.0
   sdd-apply     inherited from primary
 
-[Activate]  [Edit JSON]  [Bulk actions...]  [Profile versions...]
+[Activate]  [Bulk actions...]  [Profile versions...]
 ```
 
 ```text

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -22,6 +22,7 @@ describe('config logic', () => {
       try {
         const paths = resolvePaths();
         expect(paths.configRoot).toBe(path.join('/home/user', '.config', 'opencode'));
+        expect(paths.profileVersionsDir).toBe(path.join('/home/user', '.config', 'opencode', 'profile-versions'));
       } finally {
         process.env = originalEnv;
       }
@@ -35,6 +36,7 @@ describe('config logic', () => {
       try {
         const paths = resolvePaths();
         expect(paths.configRoot).toBe(path.join('/custom/config', 'opencode'));
+        expect(paths.profileVersionsDir).toBe(path.join('/custom/config', 'opencode', 'profile-versions'));
       } finally {
         process.env = originalEnv;
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ import { execFileSync } from "node:child_process";
 export type Paths = {
   configRoot: string;
   profilesDir: string;
+  profileVersionsDir: string;
   configPath: string;
   backupPath: string;
 };
@@ -36,6 +37,7 @@ export function resolvePaths(): Paths {
   return {
     configRoot,
     profilesDir: path.join(configRoot, "profiles"),
+    profileVersionsDir: path.join(configRoot, "profile-versions"),
     configPath: path.join(configRoot, "opencode.json"),
     backupPath: path.join(configRoot, "opencode.json.bak"),
   };

--- a/src/dialogs.test.ts
+++ b/src/dialogs.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { BULK_ASSIGNMENT_MODE, BULK_ASSIGNMENT_TARGET, PROFILE_VERSION_SOURCE } from './types';
+import { buildBulkProfileActionOptions, buildProfileVersionListOption, formatProfileVersionPreviewLines } from './dialogs';
+
+describe('dialog pure builders', () => {
+  it('builds fill-only and override bulk profile action labels mapped to target and mode', () => {
+    const options = buildBulkProfileActionOptions();
+
+    expect(options).toEqual([
+      {
+        title: 'Set all primary phases',
+        value: 'bulk:fill-only:primary',
+        operation: { target: BULK_ASSIGNMENT_TARGET.PRIMARY, mode: BULK_ASSIGNMENT_MODE.FILL_ONLY },
+        requiresConfirmation: false,
+      },
+      {
+        title: 'Set all fallback phases',
+        value: 'bulk:fill-only:fallback',
+        operation: { target: BULK_ASSIGNMENT_TARGET.FALLBACK, mode: BULK_ASSIGNMENT_MODE.FILL_ONLY },
+        requiresConfirmation: false,
+      },
+      {
+        title: 'Set all phases and fallbacks',
+        value: 'bulk:fill-only:both',
+        operation: { target: BULK_ASSIGNMENT_TARGET.BOTH, mode: BULK_ASSIGNMENT_MODE.FILL_ONLY },
+        requiresConfirmation: false,
+      },
+      {
+        title: 'Override all primary phases',
+        value: 'bulk:overwrite:primary',
+        operation: { target: BULK_ASSIGNMENT_TARGET.PRIMARY, mode: BULK_ASSIGNMENT_MODE.OVERWRITE },
+        requiresConfirmation: true,
+      },
+      {
+        title: 'Override all fallback phases',
+        value: 'bulk:overwrite:fallback',
+        operation: { target: BULK_ASSIGNMENT_TARGET.FALLBACK, mode: BULK_ASSIGNMENT_MODE.OVERWRITE },
+        requiresConfirmation: true,
+      },
+      {
+        title: 'Override all phases and fallbacks',
+        value: 'bulk:overwrite:both',
+        operation: { target: BULK_ASSIGNMENT_TARGET.BOTH, mode: BULK_ASSIGNMENT_MODE.OVERWRITE },
+        requiresConfirmation: true,
+      },
+    ]);
+  });
+
+  it('formats profile version previews with date, operation, assignments, and raw excerpt', () => {
+    const lines = formatProfileVersionPreviewLines({
+      version: 1,
+      id: 'team.json/2026-04-26T10-00-00-000Z-a.json',
+      profileFile: 'team.json',
+      createdAt: '2026-04-26T10:00:00.000Z',
+      source: PROFILE_VERSION_SOURCE.PHASE,
+      operation: { target: BULK_ASSIGNMENT_TARGET.BOTH, mode: BULK_ASSIGNMENT_MODE.FILL_ONLY },
+      operationSummary: 'Set 2 primary and 1 fallback phases',
+      beforeRaw: '{"models":{"sdd-init":"old/model"},"fallback":{"sdd-init":"old/fallback"}}',
+      preview: { models: { 'sdd-init': 'old/model' }, fallback: { 'sdd-init': 'old/fallback' } }
+    });
+
+    expect(lines).toContain('Profile: team.json');
+    expect(lines).toContain('Source: Phase');
+    expect(lines).toContain('Operation: Set 2 primary and 1 fallback phases');
+    expect(lines).toContain('Primary: sdd-init -> old/model');
+    expect(lines).toContain('Fallback: sdd-init -> old/fallback');
+    expect(lines.some((line) => line.startsWith('Raw: {"models"'))).toBe(true);
+  });
+
+  it('builds version list labels with source, date, and operation summary', () => {
+    const option = buildProfileVersionListOption({
+      version: 1,
+      id: 'team.json/2026-04-26T10-00-00-000Z-a.json',
+      profileFile: 'team.json',
+      createdAt: '2026-04-26T10:00:00.000Z',
+      source: PROFILE_VERSION_SOURCE.BULK,
+      operation: { source: PROFILE_VERSION_SOURCE.BULK, target: BULK_ASSIGNMENT_TARGET.PRIMARY, mode: BULK_ASSIGNMENT_MODE.OVERWRITE },
+      operationSummary: 'Override all primary phases: 2 primary, 0 fallback',
+      preview: { models: { 'sdd-init': 'old/model' }, fallback: {} }
+    });
+
+    expect(option).toEqual({
+      title: expect.stringContaining('Bulk'),
+      value: 'team.json/2026-04-26T10-00-00-000Z-a.json',
+      description: 'Override all primary phases: 2 primary, 0 fallback',
+    });
+    expect(option.title).toContain('2026');
+  });
+});

--- a/src/dialogs.tsx
+++ b/src/dialogs.tsx
@@ -10,7 +10,15 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { NAV_CATEGORY } from "./types";
+import {
+  BULK_ASSIGNMENT_MODE,
+  BULK_ASSIGNMENT_TARGET,
+  BulkAssignmentOperation,
+  PROFILE_VERSION_SOURCE,
+  ProfileVersion,
+  ProfileVersionMetadata,
+  NAV_CATEGORY,
+} from "./types";
 import {
   resolveModelInfo,
   formatMemoryDate,
@@ -26,11 +34,12 @@ import {
   readProfileData,
   readProfileModels,
   readProfileFallbackModels,
-  writeProfileData,
   writeProfileModels,
-  writeProfileFallbackModels,
-  assignModelToUnassignedProfilePhases,
-  extractSddAgentModels,
+  updateProfileWithBulkPhaseAssignment,
+  updateProfilePhaseModel,
+  listProfileVersions,
+  readProfileVersion,
+  restoreProfileVersion,
   detectActiveProfileFile,
   activateProfileFile,
   deleteProfileFile,
@@ -154,6 +163,80 @@ let showProfilesMenuFn: (api: any) => void;
 let showProfileListFn: (api: any) => void;
 let showProfileDetailFn: (api: any, profileOpt: any) => void;
 let showProjectMemoriesMenuFn: (api: any) => void;
+
+export type BulkProfileActionOption = {
+  title: string;
+  value: string;
+  operation: BulkAssignmentOperation;
+  requiresConfirmation: boolean;
+};
+
+export function buildBulkProfileActionOptions(): BulkProfileActionOption[] {
+  return [
+    {
+      title: "Set all primary phases",
+      value: "bulk:fill-only:primary",
+      operation: { target: BULK_ASSIGNMENT_TARGET.PRIMARY, mode: BULK_ASSIGNMENT_MODE.FILL_ONLY },
+      requiresConfirmation: false,
+    },
+    {
+      title: "Set all fallback phases",
+      value: "bulk:fill-only:fallback",
+      operation: { target: BULK_ASSIGNMENT_TARGET.FALLBACK, mode: BULK_ASSIGNMENT_MODE.FILL_ONLY },
+      requiresConfirmation: false,
+    },
+    {
+      title: "Set all phases and fallbacks",
+      value: "bulk:fill-only:both",
+      operation: { target: BULK_ASSIGNMENT_TARGET.BOTH, mode: BULK_ASSIGNMENT_MODE.FILL_ONLY },
+      requiresConfirmation: false,
+    },
+    {
+      title: "Override all primary phases",
+      value: "bulk:overwrite:primary",
+      operation: { target: BULK_ASSIGNMENT_TARGET.PRIMARY, mode: BULK_ASSIGNMENT_MODE.OVERWRITE },
+      requiresConfirmation: true,
+    },
+    {
+      title: "Override all fallback phases",
+      value: "bulk:overwrite:fallback",
+      operation: { target: BULK_ASSIGNMENT_TARGET.FALLBACK, mode: BULK_ASSIGNMENT_MODE.OVERWRITE },
+      requiresConfirmation: true,
+    },
+    {
+      title: "Override all phases and fallbacks",
+      value: "bulk:overwrite:both",
+      operation: { target: BULK_ASSIGNMENT_TARGET.BOTH, mode: BULK_ASSIGNMENT_MODE.OVERWRITE },
+      requiresConfirmation: true,
+    },
+  ];
+}
+
+export function formatProfileVersionPreviewLines(version: ProfileVersion): string[] {
+  const primaryLines = Object.entries(version.preview.models || {}).map(([name, model]) => `Primary: ${name} -> ${model}`);
+  const fallbackLines = Object.entries(version.preview.fallback || {}).map(([name, model]) => `Fallback: ${name} -> ${model}`);
+  return [
+    `Profile: ${version.profileFile}`,
+    `Created: ${formatMemoryDate(version.createdAt)}`,
+    `Source: ${formatProfileVersionSource(version.source)}`,
+    `Operation: ${version.operationSummary}`,
+    ...(primaryLines.length > 0 ? primaryLines : ["Primary: none"]),
+    ...(fallbackLines.length > 0 ? fallbackLines : ["Fallback: none"]),
+    `Raw: ${truncateText(version.beforeRaw.replace(/\s+/g, " "), 80)}`,
+  ];
+}
+
+function formatProfileVersionSource(source: string | undefined): string {
+  return source === PROFILE_VERSION_SOURCE.PHASE ? "Phase" : "Bulk";
+}
+
+export function buildProfileVersionListOption(version: ProfileVersionMetadata): { title: string; value: string; description: string } {
+  return {
+    title: `${formatMemoryDate(version.createdAt)} · ${formatProfileVersionSource(version.source)}`,
+    value: version.id,
+    description: version.operationSummary,
+  };
+}
 
 /**
  * Registers callback functions for cross-dialog navigation
@@ -347,10 +430,16 @@ export function showProfileDetail(api: any, profileOpt: any) {
         options={[
           { title: `✏ Name: ${profileOpt.title}`, value: "__rename__", category: "Profile" },
           {
-            title: "Set all phases (not set or unassigned)",
-            value: "__bulk_unassigned__",
-            description: "Choose one model for empty primary and fallback SDD phase assignments",
+            title: "Bulk actions...",
+            value: "__bulk_actions__",
+            description: "Fill or override primary and fallback SDD phase assignments",
             category: "Agents (Click to edit model)",
+          },
+          {
+            title: "Profile versions...",
+            value: "__profile_versions__",
+            description: "Preview and restore previous profile versions",
+            category: "Profile",
           },
           ...sddAgents.map(([name, modelId]) => ({
             title: name,
@@ -373,7 +462,8 @@ export function showProfileDetail(api: any, profileOpt: any) {
           else if (opt.value === "__assign__") handleActivateProfile(api, profilePath, profileOpt.title);
           else if (opt.value === "__delete__") showDeleteProfile(api, profileOpt);
           else if (opt.value === "__rename__") showRenameProfile(api, profileOpt);
-          else if (opt.value === "__bulk_unassigned__") showProviderPickerForBulkProfilePhases(api, profileOpt);
+          else if (opt.value === "__bulk_actions__") showBulkProfileActions(api, profileOpt);
+          else if (opt.value === "__profile_versions__") showProfileVersions(api, profileOpt);
           else if (!opt.value.startsWith("__") && opt.value.startsWith("model:")) {
             showProviderPickerForAgent(api, profileOpt, opt.value.replace("model:", ""), "model");
           } else if (!opt.value.startsWith("__") && opt.value.startsWith("fallback:")) {
@@ -473,20 +563,62 @@ function showRenameProfile(api: any, profileOpt: any) {
 }
 
 /**
- * Displays a menu to select a provider for bulk unassigned phase assignment.
+ * Displays bulk assignment actions for the selected profile.
  */
-function showProviderPickerForBulkProfilePhases(api: any, profileOpt: any) {
+function showBulkProfileActions(api: any, profileOpt: any) {
+  const options = buildBulkProfileActionOptions();
+
+  api.ui.dialog.replace(() => (
+    <api.ui.DialogSelect
+      title="Bulk profile actions"
+      options={[
+        ...options.map((option) => ({
+          title: option.title,
+          value: option.value,
+          description: option.requiresConfirmation ? "Requires confirmation before overwriting" : "Fill only empty or unassigned entries",
+        })),
+        { title: "← Back", value: "__back__", category: NAV_CATEGORY },
+      ]}
+      onSelect={(opt: any) => {
+        if (opt.value === "__back__") showProfileDetailFn(api, profileOpt);
+        else {
+          const selected = options.find((option) => option.value === opt.value);
+          if (!selected) return;
+          if (selected.requiresConfirmation) showConfirmBulkProfileOverride(api, profileOpt, selected);
+          else showProviderPickerForBulkProfilePhases(api, profileOpt, selected);
+        }
+      }}
+      onCancel={() => showProfileDetailFn(api, profileOpt)}
+    />
+  ));
+}
+
+function showConfirmBulkProfileOverride(api: any, profileOpt: any, action: BulkProfileActionOption) {
+  api.ui.dialog.replace(() => (
+    <api.ui.DialogConfirm
+      title="Confirm bulk override"
+      message={`${action.title} will replace existing targeted assignments in '${profileOpt.title}'. A dated version will be saved first.`}
+      onConfirm={() => showProviderPickerForBulkProfilePhases(api, profileOpt, action)}
+      onCancel={() => showBulkProfileActions(api, profileOpt)}
+    />
+  ));
+}
+
+/**
+ * Displays a menu to select a provider for bulk phase assignment.
+ */
+function showProviderPickerForBulkProfilePhases(api: any, profileOpt: any, action: BulkProfileActionOption) {
   const providers = (api.state.provider || []).filter((p: any) => Object.keys(p.models || {}).length > 0);
 
   if (providers.length === 0) {
     api.ui.toast({ title: "No Providers", message: "No authenticated providers found.", variant: "warning" });
-    showProfileDetailFn(api, profileOpt);
+    showBulkProfileActions(api, profileOpt);
     return;
   }
 
   api.ui.dialog.replace(() => (
     <api.ui.DialogSelect
-      title="Provider for unassigned SDD phases"
+      title={`Provider › ${action.title}`}
       options={[
         ...providers.map((p: any) => ({
           title: p.name || p.id,
@@ -496,27 +628,27 @@ function showProviderPickerForBulkProfilePhases(api: any, profileOpt: any) {
         { title: "← Back", value: "__back__", category: NAV_CATEGORY },
       ]}
       onSelect={(opt: any) => {
-        if (opt.value === "__back__") showProfileDetailFn(api, profileOpt);
+        if (opt.value === "__back__") showBulkProfileActions(api, profileOpt);
         else {
           const selected = providers.find((p: any) => p.id === opt.value);
-          showModelPickerForBulkProfilePhases(api, profileOpt, selected);
+          showModelPickerForBulkProfilePhases(api, profileOpt, selected, action);
         }
       }}
-      onCancel={() => showProfileDetailFn(api, profileOpt)}
+      onCancel={() => showBulkProfileActions(api, profileOpt)}
     />
   ));
 }
 
 /**
- * Displays a model picker for bulk unassigned phase assignment.
+ * Displays a model picker for bulk phase assignment.
  */
-function showModelPickerForBulkProfilePhases(api: any, profileOpt: any, provider: any) {
+function showModelPickerForBulkProfilePhases(api: any, profileOpt: any, provider: any, action: BulkProfileActionOption) {
   const models = provider.models || {};
   const modelKeys = Object.keys(models);
 
   api.ui.dialog.replace(() => (
     <api.ui.DialogSelect
-      title={`${provider.name || provider.id} › unassigned SDD phases`}
+      title={`${provider.name || provider.id} › ${action.title}`}
       options={[
         ...modelKeys.map((key) => {
           const model = models[key];
@@ -530,35 +662,32 @@ function showModelPickerForBulkProfilePhases(api: any, profileOpt: any, provider
         { title: "← Back", value: "__back__", category: NAV_CATEGORY },
       ]}
       onSelect={(opt: any) => {
-        if (opt.value === "__back__") showProviderPickerForBulkProfilePhases(api, profileOpt);
-        else updateUnassignedProfilePhases(api, profileOpt, opt.value);
+        if (opt.value === "__back__") showProviderPickerForBulkProfilePhases(api, profileOpt, action);
+        else updateBulkProfilePhases(api, profileOpt, opt.value, action);
       }}
-      onCancel={() => showProviderPickerForBulkProfilePhases(api, profileOpt)}
+      onCancel={() => showProviderPickerForBulkProfilePhases(api, profileOpt, action)}
     />
   ));
 }
 
 /**
- * Assigns the selected model to unassigned primary and fallback SDD profile phases.
+ * Assigns the selected model to targeted SDD profile phases and versions before mutation.
  */
-function updateUnassignedProfilePhases(api: any, profileOpt: any, fullModelId: string) {
+function updateBulkProfilePhases(api: any, profileOpt: any, fullModelId: string, action: BulkProfileActionOption) {
   const { profilesDir } = resolvePaths();
   const profilePath = path.join(profilesDir, profileOpt.value);
 
   try {
-    const profileData = readProfileData(profilePath);
     const primarySddAgentNames = Object.keys(api.state.config?.agent || {}).filter(isPrimarySddAgent);
-    const result = assignModelToUnassignedProfilePhases(profileData, primarySddAgentNames, fullModelId);
+    const { assignment } = updateProfileWithBulkPhaseAssignment(profilePath, primarySddAgentNames, fullModelId, action.operation);
 
-    writeProfileData(profilePath, result.profile);
-
-    const totalAssigned = result.modelsAssigned + result.fallbackAssigned;
+    const totalAssigned = assignment.modelsAssigned + assignment.fallbackAssigned;
     api.ui.toast({
       title: totalAssigned > 0 ? "Updated" : "No Changes",
       message:
         totalAssigned > 0
-          ? `Set ${result.modelsAssigned} primary and ${result.fallbackAssigned} fallback unassigned phases to ${fullModelId}`
-          : "No unassigned SDD primary or fallback phases required updates",
+          ? `${action.title}: ${assignment.modelsAssigned} primary and ${assignment.fallbackAssigned} fallback assignments set to ${fullModelId}. Version saved.`
+          : "No targeted SDD primary or fallback phases required updates",
       variant: totalAssigned > 0 ? "success" : "warning",
     });
     showProfileDetailFn(api, profileOpt);
@@ -566,6 +695,83 @@ function updateUnassignedProfilePhases(api: any, profileOpt: any, fullModelId: s
     api.ui.toast({ title: "Error", message: `Failed to update phases: ${e.message}`, variant: "error" });
     showProfileDetailFn(api, profileOpt);
   }
+}
+
+function showProfileVersions(api: any, profileOpt: any) {
+  try {
+    const versions = listProfileVersions(profileOpt.value);
+
+    if (versions.length === 0) {
+      api.ui.toast({ title: "No Versions", message: `No saved versions for '${profileOpt.title}'`, variant: "warning" });
+      showProfileDetailFn(api, profileOpt);
+      return;
+    }
+
+    api.ui.dialog.replace(() => (
+      <api.ui.DialogSelect
+        title={`Versions: ${profileOpt.title}`}
+        options={[
+          ...versions.map(buildProfileVersionListOption),
+          { title: "← Back", value: "__back__", category: NAV_CATEGORY },
+        ]}
+        onSelect={(opt: any) => {
+          if (opt.value === "__back__") showProfileDetailFn(api, profileOpt);
+          else showProfileVersionPreview(api, profileOpt, opt.value);
+        }}
+        onCancel={() => showProfileDetailFn(api, profileOpt)}
+      />
+    ));
+  } catch (e: any) {
+    api.ui.toast({ title: "Version Error", message: e.message || "Failed to list profile versions", variant: "error" });
+    showProfileDetailFn(api, profileOpt);
+  }
+}
+
+function showProfileVersionPreview(api: any, profileOpt: any, versionId: string) {
+  try {
+    const version = readProfileVersion(versionId);
+    const lines = formatProfileVersionPreviewLines(version);
+
+    api.ui.dialog.replace(() => (
+      <api.ui.DialogSelect
+        title={`Preview: ${profileOpt.title}`}
+        options={[
+          ...lines.map((line, index) => ({ title: line, value: `__line__${index}` })),
+          { title: "↩ Restore this version", value: "__restore__", category: NAV_CATEGORY },
+          { title: "← Back", value: "__back__", category: NAV_CATEGORY },
+        ]}
+        onSelect={(opt: any) => {
+          if (opt.value === "__restore__") showConfirmRestoreProfileVersion(api, profileOpt, version.id);
+          else if (opt.value === "__back__") showProfileVersions(api, profileOpt);
+          else showProfileVersionPreview(api, profileOpt, versionId);
+        }}
+        onCancel={() => showProfileVersions(api, profileOpt)}
+      />
+    ));
+  } catch (e: any) {
+    api.ui.toast({ title: "Version Error", message: e.message || "Failed to read profile version", variant: "error" });
+    showProfileVersions(api, profileOpt);
+  }
+}
+
+function showConfirmRestoreProfileVersion(api: any, profileOpt: any, versionId: string) {
+  api.ui.dialog.replace(() => (
+    <api.ui.DialogConfirm
+      title="Restore profile version"
+      message={`Restore '${profileOpt.title}' from this version? Current profile content will be overwritten.`}
+      onConfirm={() => {
+        try {
+          restoreProfileVersion(profileOpt.value, versionId);
+          api.ui.toast({ title: "Restored", message: `Profile '${profileOpt.title}' restored`, variant: "success" });
+          showProfileDetailFn(api, profileOpt);
+        } catch (e: any) {
+          api.ui.toast({ title: "Restore Failed", message: e.message || "Failed to restore version", variant: "error" });
+          showProfileVersionPreview(api, profileOpt, versionId);
+        }
+      }}
+      onCancel={() => showProfileVersionPreview(api, profileOpt, versionId)}
+    />
+  ));
 }
 
 /**
@@ -655,15 +861,23 @@ function updateAgentModel(
 
   try {
     if (mode === "fallback") {
-      const fallbackModels = readProfileFallbackModels(profilePath);
-      fallbackModels[agentName] = fullModelId;
-      writeProfileFallbackModels(profilePath, fallbackModels);
-      api.ui.toast({ title: "Updated", message: `${agentName} fallback set to ${fullModelId}`, variant: "success" });
+      const result = updateProfilePhaseModel(profilePath, agentName, "fallback", fullModelId);
+      api.ui.toast({
+        title: result.changed ? "Updated" : "No Changes",
+        message: result.changed
+          ? `${agentName} fallback set to ${fullModelId}. Version saved.`
+          : `${agentName} fallback already uses ${fullModelId}`,
+        variant: result.changed ? "success" : "warning",
+      });
     } else {
-      const profileModels = readProfileModels(profilePath);
-      profileModels[agentName] = fullModelId;
-      writeProfileModels(profilePath, profileModels);
-      api.ui.toast({ title: "Updated", message: `${agentName} set to ${fullModelId}`, variant: "success" });
+      const result = updateProfilePhaseModel(profilePath, agentName, "primary", fullModelId);
+      api.ui.toast({
+        title: result.changed ? "Updated" : "No Changes",
+        message: result.changed
+          ? `${agentName} set to ${fullModelId}. Version saved.`
+          : `${agentName} already uses ${fullModelId}`,
+        variant: result.changed ? "success" : "warning",
+      });
     }
     showProfileDetailFn(api, profileOpt);
   } catch (e: any) {

--- a/src/dialogs.tsx
+++ b/src/dialogs.tsx
@@ -26,8 +26,10 @@ import {
   readProfileData,
   readProfileModels,
   readProfileFallbackModels,
+  writeProfileData,
   writeProfileModels,
   writeProfileFallbackModels,
+  assignModelToUnassignedProfilePhases,
   extractSddAgentModels,
   detectActiveProfileFile,
   activateProfileFile,
@@ -344,6 +346,12 @@ export function showProfileDetail(api: any, profileOpt: any) {
         title={`Profile: ${profileOpt.title}`}
         options={[
           { title: `✏ Name: ${profileOpt.title}`, value: "__rename__", category: "Profile" },
+          {
+            title: "Set all phases (not set or unassigned)",
+            value: "__bulk_unassigned__",
+            description: "Choose one model for empty primary and fallback SDD phase assignments",
+            category: "Agents (Click to edit model)",
+          },
           ...sddAgents.map(([name, modelId]) => ({
             title: name,
             value: `model:${name}`,
@@ -365,6 +373,7 @@ export function showProfileDetail(api: any, profileOpt: any) {
           else if (opt.value === "__assign__") handleActivateProfile(api, profilePath, profileOpt.title);
           else if (opt.value === "__delete__") showDeleteProfile(api, profileOpt);
           else if (opt.value === "__rename__") showRenameProfile(api, profileOpt);
+          else if (opt.value === "__bulk_unassigned__") showProviderPickerForBulkProfilePhases(api, profileOpt);
           else if (!opt.value.startsWith("__") && opt.value.startsWith("model:")) {
             showProviderPickerForAgent(api, profileOpt, opt.value.replace("model:", ""), "model");
           } else if (!opt.value.startsWith("__") && opt.value.startsWith("fallback:")) {
@@ -461,6 +470,102 @@ function showRenameProfile(api: any, profileOpt: any) {
       onCancel={() => showProfileDetailFn(api, profileOpt)}
     />
   ));
+}
+
+/**
+ * Displays a menu to select a provider for bulk unassigned phase assignment.
+ */
+function showProviderPickerForBulkProfilePhases(api: any, profileOpt: any) {
+  const providers = (api.state.provider || []).filter((p: any) => Object.keys(p.models || {}).length > 0);
+
+  if (providers.length === 0) {
+    api.ui.toast({ title: "No Providers", message: "No authenticated providers found.", variant: "warning" });
+    showProfileDetailFn(api, profileOpt);
+    return;
+  }
+
+  api.ui.dialog.replace(() => (
+    <api.ui.DialogSelect
+      title="Provider for unassigned SDD phases"
+      options={[
+        ...providers.map((p: any) => ({
+          title: p.name || p.id,
+          value: p.id,
+          description: `${Object.keys(p.models || {}).length} models available`,
+        })),
+        { title: "← Back", value: "__back__", category: NAV_CATEGORY },
+      ]}
+      onSelect={(opt: any) => {
+        if (opt.value === "__back__") showProfileDetailFn(api, profileOpt);
+        else {
+          const selected = providers.find((p: any) => p.id === opt.value);
+          showModelPickerForBulkProfilePhases(api, profileOpt, selected);
+        }
+      }}
+      onCancel={() => showProfileDetailFn(api, profileOpt)}
+    />
+  ));
+}
+
+/**
+ * Displays a model picker for bulk unassigned phase assignment.
+ */
+function showModelPickerForBulkProfilePhases(api: any, profileOpt: any, provider: any) {
+  const models = provider.models || {};
+  const modelKeys = Object.keys(models);
+
+  api.ui.dialog.replace(() => (
+    <api.ui.DialogSelect
+      title={`${provider.name || provider.id} › unassigned SDD phases`}
+      options={[
+        ...modelKeys.map((key) => {
+          const model = models[key];
+          const ctxText = model.limit?.context ? formatContext(model.limit.context) : "ctx: N/A";
+          return {
+            title: model.name || key,
+            value: `${provider.id}/${key}`,
+            description: ctxText,
+          };
+        }),
+        { title: "← Back", value: "__back__", category: NAV_CATEGORY },
+      ]}
+      onSelect={(opt: any) => {
+        if (opt.value === "__back__") showProviderPickerForBulkProfilePhases(api, profileOpt);
+        else updateUnassignedProfilePhases(api, profileOpt, opt.value);
+      }}
+      onCancel={() => showProviderPickerForBulkProfilePhases(api, profileOpt)}
+    />
+  ));
+}
+
+/**
+ * Assigns the selected model to unassigned primary and fallback SDD profile phases.
+ */
+function updateUnassignedProfilePhases(api: any, profileOpt: any, fullModelId: string) {
+  const { profilesDir } = resolvePaths();
+  const profilePath = path.join(profilesDir, profileOpt.value);
+
+  try {
+    const profileData = readProfileData(profilePath);
+    const primarySddAgentNames = Object.keys(api.state.config?.agent || {}).filter(isPrimarySddAgent);
+    const result = assignModelToUnassignedProfilePhases(profileData, primarySddAgentNames, fullModelId);
+
+    writeProfileData(profilePath, result.profile);
+
+    const totalAssigned = result.modelsAssigned + result.fallbackAssigned;
+    api.ui.toast({
+      title: totalAssigned > 0 ? "Updated" : "No Changes",
+      message:
+        totalAssigned > 0
+          ? `Set ${result.modelsAssigned} primary and ${result.fallbackAssigned} fallback unassigned phases to ${fullModelId}`
+          : "No unassigned SDD primary or fallback phases required updates",
+      variant: totalAssigned > 0 ? "success" : "warning",
+    });
+    showProfileDetailFn(api, profileOpt);
+  } catch (e: any) {
+    api.ui.toast({ title: "Error", message: `Failed to update phases: ${e.message}`, variant: "error" });
+    showProfileDetailFn(api, profileOpt);
+  }
 }
 
 /**

--- a/src/dialogs.tsx
+++ b/src/dialogs.tsx
@@ -32,8 +32,7 @@ import { resolvePaths, ensureProfilesDir, resolveProjectName } from "./config";
 import {
   listProfileFiles,
   readProfileData,
-  readProfileModels,
-  readProfileFallbackModels,
+  sanitizeProfileName,
   writeProfileModels,
   updateProfileWithBulkPhaseAssignment,
   updateProfilePhaseModel,
@@ -317,21 +316,21 @@ export function showCreateProfile(api: any) {
           return;
         }
 
-        const finalName = trimmed.replace(/\.json$/i, "");
-        const fileName = `${finalName}.json`;
-        const profilePath = path.join(profilesDir, fileName);
-
-        if (fs.existsSync(profilePath)) {
-          api.ui.toast({
-            title: "Error",
-            message: `Profile '${finalName}' already exists`,
-            variant: "error",
-          });
-          showProfilesMenuFn(api);
-          return;
-        }
-
         try {
+          const finalName = sanitizeProfileName(trimmed);
+          const fileName = `${finalName}.json`;
+          const profilePath = path.join(profilesDir, fileName);
+
+          if (fs.existsSync(profilePath)) {
+            api.ui.toast({
+              title: "Error",
+              message: `Profile '${finalName}' already exists`,
+              variant: "error",
+            });
+            showProfilesMenuFn(api);
+            return;
+          }
+
           writeProfileModels(profilePath, {});
           
           // Defer both navigation and toast to next tick to ensure the current 
@@ -536,19 +535,19 @@ function showRenameProfile(api: any, profileOpt: any) {
           return;
         }
 
-        const finalName = trimmed.replace(/\.json$/i, "");
-        const newFileName = `${finalName}.json`;
-
-        const { profilesDir } = resolvePaths();
-        const newPath = path.join(profilesDir, newFileName);
-
-        if (fs.existsSync(newPath)) {
-          api.ui.toast({ title: "Error", message: "A profile with this name already exists", variant: "error" });
-          showProfileDetailFn(api, profileOpt);
-          return;
-        }
-
         try {
+          const finalName = sanitizeProfileName(trimmed);
+          const newFileName = `${finalName}.json`;
+
+          const { profilesDir } = resolvePaths();
+          const newPath = path.join(profilesDir, newFileName);
+
+          if (fs.existsSync(newPath)) {
+            api.ui.toast({ title: "Error", message: "A profile with this name already exists", variant: "error" });
+            showProfileDetailFn(api, profileOpt);
+            return;
+          }
+
           renameProfileFile(profileOpt.value, newFileName);
           api.ui.toast({ title: "Renamed", message: `Profile renamed to '${finalName}'` });
           showProfileListFn(api);

--- a/src/profiles.test.ts
+++ b/src/profiles.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as fs from 'node:fs';
 import type { ProfileData } from './types';
+import { BULK_ASSIGNMENT_MODE, BULK_ASSIGNMENT_TARGET, PROFILE_VERSION_SOURCE } from './types';
 import { 
   extractSddAgentModels, 
   extractSddFallbackModels, 
@@ -10,9 +11,16 @@ import {
   validateProfileFallbackMapping,
   isSddProfile,
   applyProfileDataToConfig,
+  applyBulkProfilePhaseAssignment,
   assignModelToUnassignedProfilePhases,
   readProfileData,
-  writeProfileData
+  writeProfileData,
+  createProfileVersion,
+  listProfileVersions,
+  readProfileVersion,
+  restoreProfileVersion,
+  updateProfileWithBulkPhaseAssignment,
+  updateProfilePhaseModel
 } from './profiles';
 
 vi.mock('node:fs');
@@ -20,7 +28,9 @@ vi.mock('./config', () => ({
   resolvePaths: () => ({
     profilesDir: '/mock/profiles',
     configRoot: '/mock/config',
-    configPath: '/mock/config/opencode.json'
+    configPath: '/mock/config/opencode.json',
+    backupPath: '/mock/config/opencode.json.bak',
+    profileVersionsDir: '/mock/config/profile-versions'
   }),
   ensureProfilesDir: vi.fn()
 }));
@@ -379,6 +389,362 @@ describe('profiles logic', () => {
         assignModelToUnassignedProfilePhases(profile, ['sdd-init'], '   ')
       ).toThrow('modelId must be a non-empty string');
       expect(profile.models['sdd-init']).toBe('');
+    });
+  });
+
+  describe('applyBulkProfilePhaseAssignment', () => {
+    const agents = ['sdd-init', 'sdd-spec', 'sdd-design', 'sdd-apply', 'sdd-orchestrator', 'sdd-init-fallback', 'general'];
+
+    it('fills only unassigned primary phase models without touching fallbacks', () => {
+      const profile: ProfileData = {
+        models: { 'sdd-init': '', 'sdd-spec': 'existing/spec', 'sdd-design': '   ' },
+        fallback: { 'sdd-init': 'fallback/existing' }
+      };
+
+      const result = applyBulkProfilePhaseAssignment(profile, agents, 'provider/model', {
+        target: BULK_ASSIGNMENT_TARGET.PRIMARY,
+        mode: BULK_ASSIGNMENT_MODE.FILL_ONLY
+      });
+
+      expect(result.changed).toBe(true);
+      expect(result.modelsAssigned).toBe(4);
+      expect(result.fallbackAssigned).toBe(0);
+      expect(result.profile.models).toEqual({
+        'sdd-init': 'provider/model',
+        'sdd-spec': 'existing/spec',
+        'sdd-design': 'provider/model',
+        'sdd-apply': 'provider/model',
+        'sdd-orchestrator': 'provider/model'
+      });
+      expect(result.profile.fallback).toEqual({ 'sdd-init': 'fallback/existing' });
+      expect(profile.models['sdd-init']).toBe('');
+    });
+
+    it('fills only unassigned fallback phase models without touching primary models', () => {
+      const profile: ProfileData = {
+        models: { 'sdd-init': 'primary/existing' },
+        fallback: { 'sdd-init': '', 'sdd-spec': 'fallback/existing' }
+      };
+
+      const result = applyBulkProfilePhaseAssignment(profile, agents, 'provider/model', {
+        target: BULK_ASSIGNMENT_TARGET.FALLBACK,
+        mode: BULK_ASSIGNMENT_MODE.FILL_ONLY
+      });
+
+      expect(result.changed).toBe(true);
+      expect(result.modelsAssigned).toBe(0);
+      expect(result.fallbackAssigned).toBe(3);
+      expect(result.profile.models).toEqual({ 'sdd-init': 'primary/existing' });
+      expect(result.profile.fallback).toEqual({
+        'sdd-init': 'provider/model',
+        'sdd-spec': 'fallback/existing',
+        'sdd-design': 'provider/model',
+        'sdd-apply': 'provider/model'
+      });
+      expect(result.profile.fallback?.['sdd-orchestrator']).toBeUndefined();
+    });
+
+    it('fills unassigned primary and fallback phase models for both target', () => {
+      const result = applyBulkProfilePhaseAssignment({ models: {}, fallback: {} }, agents, 'provider/model', {
+        target: BULK_ASSIGNMENT_TARGET.BOTH,
+        mode: BULK_ASSIGNMENT_MODE.FILL_ONLY
+      });
+
+      expect(result.changed).toBe(true);
+      expect(result.modelsAssigned).toBe(5);
+      expect(result.fallbackAssigned).toBe(4);
+      expect(result.profile.models['sdd-orchestrator']).toBe('provider/model');
+      expect(result.profile.fallback?.['sdd-orchestrator']).toBeUndefined();
+      expect(result.profile.models['sdd-init-fallback']).toBeUndefined();
+    });
+
+    it('overrides only primary phase models for primary target', () => {
+      const profile: ProfileData = {
+        models: { 'sdd-init': 'old/init', 'sdd-spec': 'old/spec' },
+        fallback: { 'sdd-init': 'fallback/old' }
+      };
+
+      const result = applyBulkProfilePhaseAssignment(profile, agents, 'provider/new', {
+        target: BULK_ASSIGNMENT_TARGET.PRIMARY,
+        mode: BULK_ASSIGNMENT_MODE.OVERWRITE
+      });
+
+      expect(result.changed).toBe(true);
+      expect(result.modelsAssigned).toBe(5);
+      expect(result.fallbackAssigned).toBe(0);
+      expect(result.profile.models['sdd-init']).toBe('provider/new');
+      expect(result.profile.models['sdd-orchestrator']).toBe('provider/new');
+      expect(result.profile.fallback).toEqual({ 'sdd-init': 'fallback/old' });
+    });
+
+    it('overrides only fallback phase models for fallback target', () => {
+      const profile: ProfileData = {
+        models: { 'sdd-init': 'primary/old' },
+        fallback: { 'sdd-init': 'fallback/old', 'sdd-apply': 'fallback/apply' }
+      };
+
+      const result = applyBulkProfilePhaseAssignment(profile, agents, 'provider/new', {
+        target: BULK_ASSIGNMENT_TARGET.FALLBACK,
+        mode: BULK_ASSIGNMENT_MODE.OVERWRITE
+      });
+
+      expect(result.changed).toBe(true);
+      expect(result.modelsAssigned).toBe(0);
+      expect(result.fallbackAssigned).toBe(4);
+      expect(result.profile.models).toEqual({ 'sdd-init': 'primary/old' });
+      expect(result.profile.fallback?.['sdd-init']).toBe('provider/new');
+      expect(result.profile.fallback?.['sdd-orchestrator']).toBeUndefined();
+    });
+
+    it('overrides primary and fallback phase models for both target', () => {
+      const result = applyBulkProfilePhaseAssignment(
+        { models: { 'sdd-init': 'old' }, fallback: { 'sdd-init': 'old-fallback' } },
+        agents,
+        'provider/new',
+        { target: BULK_ASSIGNMENT_TARGET.BOTH, mode: BULK_ASSIGNMENT_MODE.OVERWRITE }
+      );
+
+      expect(result.changed).toBe(true);
+      expect(result.modelsAssigned).toBe(5);
+      expect(result.fallbackAssigned).toBe(4);
+      expect(result.profile.models['sdd-init']).toBe('provider/new');
+      expect(result.profile.fallback?.['sdd-init']).toBe('provider/new');
+    });
+
+    it('rejects blank models and reports no change for fill-only no-op', () => {
+      const profile: ProfileData = { models: { 'sdd-init': 'existing' }, fallback: { 'sdd-init': 'existing-fallback' } };
+
+      expect(() => applyBulkProfilePhaseAssignment(profile, ['sdd-init'], '   ', {
+        target: BULK_ASSIGNMENT_TARGET.BOTH,
+        mode: BULK_ASSIGNMENT_MODE.FILL_ONLY
+      })).toThrow('modelId must be a non-empty string');
+
+      const noOp = applyBulkProfilePhaseAssignment(profile, ['sdd-init'], 'provider/model', {
+        target: BULK_ASSIGNMENT_TARGET.BOTH,
+        mode: BULK_ASSIGNMENT_MODE.FILL_ONLY
+      });
+      expect(noOp.changed).toBe(false);
+      expect(noOp.profile).toEqual(profile);
+    });
+  });
+
+  describe('profile versions', () => {
+    const operation = { target: BULK_ASSIGNMENT_TARGET.BOTH, mode: BULK_ASSIGNMENT_MODE.FILL_ONLY };
+
+    it('creates dated profile versions under controlled storage with raw content and preview metadata', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.readdirSync).mockReturnValue([] as any);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        models: { 'sdd-init': 'old/model' },
+        fallback: { 'sdd-init': 'old/fallback' }
+      }));
+
+      const version = createProfileVersion('/mock/profiles/team.json', operation, 'Bulk fill both');
+
+      expect(version.profileFile).toBe('team.json');
+      expect(version.source).toBe(PROFILE_VERSION_SOURCE.BULK);
+      expect(version.operationSummary).toBe('Bulk fill both');
+      expect(version.beforeRaw).toContain('old/model');
+      expect(version.preview.models).toEqual({ 'sdd-init': 'old/model' });
+      expect(version.preview.fallback).toEqual({ 'sdd-init': 'old/fallback' });
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/mock\/config\/profile-versions\/team\.json\/\d{4}-/),
+        expect.stringContaining('"beforeRaw"')
+      );
+    });
+
+    it('normalizes legacy versions without source as bulk versions', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        version: 1,
+        id: 'team.json/2026-04-26T10-00-00-000Z-a.json',
+        profileFile: 'team.json',
+        createdAt: '2026-04-26T10:00:00.000Z',
+        operation,
+        operationSummary: 'Legacy bulk fill both',
+        beforeRaw: '{"models":{"sdd-init":"old"}}',
+        preview: { models: { 'sdd-init': 'old' }, fallback: {} }
+      }));
+
+      const version = readProfileVersion('team.json/2026-04-26T10-00-00-000Z-a.json');
+
+      expect(version.source).toBe(PROFILE_VERSION_SOURCE.BULK);
+      expect(version.operation).toEqual({
+        source: PROFILE_VERSION_SOURCE.BULK,
+        target: BULK_ASSIGNMENT_TARGET.BOTH,
+        mode: BULK_ASSIGNMENT_MODE.FILL_ONLY,
+      });
+    });
+
+    it('prunes profile versions to the newest 30 snapshots', () => {
+      const existingFiles = Array.from({ length: 31 }, (_, index) => {
+        const hour = String(index).padStart(2, '0');
+        return `2026-04-26T${hour}-00-00-000Z-${index}.json`;
+      });
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue(existingFiles as any);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ models: { 'sdd-init': 'old/model' }, fallback: {} }));
+
+      createProfileVersion('/mock/profiles/team.json', operation, 'Bulk fill both');
+
+      expect(fs.unlinkSync).toHaveBeenCalledTimes(1);
+      expect(fs.unlinkSync).toHaveBeenCalledWith('/mock/config/profile-versions/team.json/2026-04-26T00-00-00-000Z-0.json');
+    });
+
+    it('lists newest versions and reads previews by safe version id', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue(['2026-04-26T10-00-00-000Z-a.json', '2026-04-26T11-00-00-000Z-b.json'] as any);
+      vi.mocked(fs.readFileSync).mockImplementation((filePath: any) => JSON.stringify({
+        version: 1,
+        id: String(filePath).includes('11-00') ? 'team.json/2026-04-26T11-00-00-000Z-b.json' : 'team.json/2026-04-26T10-00-00-000Z-a.json',
+        profileFile: 'team.json',
+        createdAt: String(filePath).includes('11-00') ? '2026-04-26T11:00:00.000Z' : '2026-04-26T10:00:00.000Z',
+        operation,
+        operationSummary: 'Bulk fill both',
+        beforeRaw: '{"models":{"sdd-init":"old"}}',
+        preview: { models: { 'sdd-init': 'old' }, fallback: {} }
+      }));
+
+      const versions = listProfileVersions('team.json');
+      const read = readProfileVersion(versions[0].id);
+
+      expect(versions.map((item) => item.createdAt)).toEqual(['2026-04-26T11:00:00.000Z', '2026-04-26T10:00:00.000Z']);
+      expect(read.preview.models).toEqual({ 'sdd-init': 'old' });
+      expect(() => readProfileVersion('../evil.json')).toThrow('Invalid profile version id');
+    });
+
+    it('restores only the selected profile from version raw content', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        version: 1,
+        id: 'team.json/2026-04-26T10-00-00-000Z-a.json',
+        profileFile: 'team.json',
+        createdAt: '2026-04-26T10:00:00.000Z',
+        operation,
+        operationSummary: 'Bulk fill both',
+        beforeRaw: '{"models":{"sdd-init":"old/model"}}',
+        preview: { models: { 'sdd-init': 'old/model' }, fallback: {} }
+      }));
+
+      const restored = restoreProfileVersion('team.json', 'team.json/2026-04-26T10-00-00-000Z-a.json');
+
+      expect(restored.profileFile).toBe('team.json');
+      expect(fs.writeFileSync).toHaveBeenCalledWith('/mock/profiles/team.json', '{"models":{"sdd-init":"old/model"}}');
+      expect(() => restoreProfileVersion('other.json', 'team.json/2026-04-26T10-00-00-000Z-a.json')).toThrow('does not match selected profile');
+    });
+
+    it('creates a version before mutating bulk write and skips versioning for no-op or validation failure', () => {
+      const writes: string[] = [];
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.readdirSync).mockReturnValue([] as any);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ models: { 'sdd-init': '' }, fallback: {} }));
+      vi.mocked(fs.writeFileSync).mockImplementation((filePath: any) => { writes.push(String(filePath)); });
+
+      const result = updateProfileWithBulkPhaseAssignment('/mock/profiles/team.json', ['sdd-init'], 'provider/model', operation);
+
+      expect(result.assignment.changed).toBe(true);
+      expect(writes[0]).toContain('/mock/config/profile-versions/team.json/');
+      expect(writes[1]).toBe('/mock/profiles/team.json');
+
+      vi.clearAllMocks();
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ models: { 'sdd-init': 'existing' }, fallback: { 'sdd-init': 'existing' } }));
+      const noOp = updateProfileWithBulkPhaseAssignment('/mock/profiles/team.json', ['sdd-init'], 'provider/model', operation);
+      expect(noOp.assignment.changed).toBe(false);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+
+      expect(() => updateProfileWithBulkPhaseAssignment('/mock/profiles/team.json', ['sdd-init'], ' ', operation)).toThrow('modelId must be a non-empty string');
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('creates a phase source version before mutating a single primary phase model', () => {
+      const writes: string[] = [];
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.readdirSync).mockReturnValue([] as any);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        models: { 'sdd-design': 'old/model' },
+        fallback: { 'sdd-design': 'old/fallback' },
+        description: 'team defaults'
+      }));
+      vi.mocked(fs.writeFileSync).mockImplementation((filePath: any) => { writes.push(String(filePath)); });
+
+      const result = updateProfilePhaseModel('/mock/profiles/team.json', 'sdd-design', 'primary', 'new/model');
+
+      expect(result.changed).toBe(true);
+      expect(result.version?.source).toBe(PROFILE_VERSION_SOURCE.PHASE);
+      expect(result.version?.operation).toEqual({
+        source: PROFILE_VERSION_SOURCE.PHASE,
+        phase: 'sdd-design',
+        field: 'primary',
+        modelId: 'new/model',
+        changedPhases: 1,
+      });
+      expect(result.version?.operationSummary).toBe('Set sdd-design primary model to new/model');
+      expect(result.profile.models['sdd-design']).toBe('new/model');
+      expect(result.profile.fallback?.['sdd-design']).toBe('old/fallback');
+      expect((result.profile as any).description).toBe('team defaults');
+      expect(writes[0]).toContain('/mock/config/profile-versions/team.json/');
+      expect(writes[1]).toBe('/mock/profiles/team.json');
+    });
+
+    it('does not persist version metadata in the profile payload for phase model updates', () => {
+      const writes: Array<{ filePath: string; content: string }> = [];
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.readdirSync).mockReturnValue([] as any);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        models: { 'sdd-design': 'old/model' },
+        fallback: { 'sdd-design': 'old/fallback' },
+        description: 'team defaults'
+      }));
+      vi.mocked(fs.writeFileSync).mockImplementation((filePath: any, content: any) => {
+        writes.push({ filePath: String(filePath), content: String(content) });
+      });
+
+      updateProfilePhaseModel('/mock/profiles/team.json', 'sdd-design', 'primary', 'new/model');
+
+      const profileWrite = writes.find((write) => write.filePath === '/mock/profiles/team.json');
+      expect(profileWrite).toBeDefined();
+
+      const persistedProfile = JSON.parse(profileWrite!.content);
+      expect(persistedProfile).toEqual({
+        models: { 'sdd-design': 'new/model' },
+        fallback: { 'sdd-design': 'old/fallback' },
+        description: 'team defaults'
+      });
+      expect(persistedProfile).not.toHaveProperty('source');
+      expect(persistedProfile).not.toHaveProperty('operation');
+      expect(persistedProfile).not.toHaveProperty('operationSummary');
+      expect(persistedProfile).not.toHaveProperty('beforeRaw');
+    });
+
+    it('creates a phase source version before mutating a single fallback phase model', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.readdirSync).mockReturnValue([] as any);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        models: { 'sdd-apply': 'old/model' },
+        fallback: { 'sdd-apply': 'old/fallback' }
+      }));
+
+      const result = updateProfilePhaseModel('/mock/profiles/team.json', 'sdd-apply', 'fallback', 'new/fallback');
+
+      expect(result.changed).toBe(true);
+      expect(result.version?.source).toBe(PROFILE_VERSION_SOURCE.PHASE);
+      expect(result.version?.operationSummary).toBe('Set sdd-apply fallback model to new/fallback');
+      expect(result.profile.models['sdd-apply']).toBe('old/model');
+      expect(result.profile.fallback?.['sdd-apply']).toBe('new/fallback');
+    });
+
+    it('skips versioning and profile writes for no-op single phase model updates', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        models: { 'sdd-design': 'new/model' },
+        fallback: { 'sdd-design': 'new/fallback' }
+      }));
+
+      const primaryNoOp = updateProfilePhaseModel('/mock/profiles/team.json', 'sdd-design', 'primary', 'new/model');
+      const fallbackNoOp = updateProfilePhaseModel('/mock/profiles/team.json', 'sdd-design', 'fallback', 'new/fallback');
+
+      expect(primaryNoOp.changed).toBe(false);
+      expect(fallbackNoOp.changed).toBe(false);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/profiles.test.ts
+++ b/src/profiles.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as fs from 'node:fs';
+import type { ProfileData } from './types';
 import { 
   extractSddAgentModels, 
   extractSddFallbackModels, 
@@ -8,7 +9,10 @@ import {
   syncSddFallbackAgents, 
   validateProfileFallbackMapping,
   isSddProfile,
-  applyProfileDataToConfig
+  applyProfileDataToConfig,
+  assignModelToUnassignedProfilePhases,
+  readProfileData,
+  writeProfileData
 } from './profiles';
 
 vi.mock('node:fs');
@@ -116,6 +120,30 @@ describe('profiles logic', () => {
     });
   });
 
+  describe('readProfileData and writeProfileData', () => {
+    it('preserves unrelated profile fields when reading and writing full profile data', () => {
+      const mockContent = JSON.stringify({
+        models: { 'sdd-init': 'gpt-4' },
+        fallback: { 'sdd-init': 'gpt-3.5' },
+        description: 'team defaults'
+      });
+      vi.mocked(fs.readFileSync).mockReturnValue(mockContent);
+
+      const profileData = readProfileData('/mock/profiles/compatible.json');
+      writeProfileData('/mock/profiles/compatible.json', profileData);
+
+      expect(profileData).toEqual({
+        models: { 'sdd-init': 'gpt-4' },
+        fallback: { 'sdd-init': 'gpt-3.5' },
+        description: 'team defaults'
+      });
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/mock/profiles/compatible.json',
+        JSON.stringify(profileData, null, 2)
+      );
+    });
+  });
+
   describe('validateProfileFallbackMapping', () => {
     it('should return empty list on success', () => {
       const config = {
@@ -216,6 +244,141 @@ describe('profiles logic', () => {
       const nextConfig = applyProfileDataToConfig(config, profile);
       expect(nextConfig.agent['sdd-init'].model).toBe('claude-3');
       expect(nextConfig.agent['sdd-init-fallback'].model).toBe('gpt-3.5');
+    });
+  });
+
+  describe('assignModelToUnassignedProfilePhases', () => {
+    it('fills missing and blank primary SDD model assignments', () => {
+      const profile = {
+        models: {
+          'sdd-init': '',
+          'sdd-spec': '   ',
+          'sdd-design': 'existing/provider',
+        },
+        fallback: {}
+      };
+
+      const result = assignModelToUnassignedProfilePhases(
+        profile,
+        ['sdd-init', 'sdd-apply', 'sdd-spec', 'sdd-design'],
+        'provider/model'
+      );
+
+      expect(result.modelsAssigned).toBe(3);
+      expect(result.profile.models).toEqual({
+        'sdd-init': 'provider/model',
+        'sdd-apply': 'provider/model',
+        'sdd-spec': 'provider/model',
+        'sdd-design': 'existing/provider',
+      });
+      expect(profile.models['sdd-init']).toBe('');
+    });
+
+    it('fills missing and blank fallback entries only for fallback-eligible SDD agents', () => {
+      const profile = {
+        models: {},
+        fallback: {
+          'sdd-init': '',
+          'sdd-apply': '   ',
+          'sdd-spec': 'fallback/existing'
+        }
+      };
+
+      const result = assignModelToUnassignedProfilePhases(
+        profile,
+        ['sdd-init', 'sdd-apply', 'sdd-orchestrator', 'not-sdd'],
+        'provider/model'
+      );
+
+      expect(result.fallbackAssigned).toBe(2);
+      expect(result.profile.fallback).toEqual({
+        'sdd-init': 'provider/model',
+        'sdd-apply': 'provider/model',
+        'sdd-spec': 'fallback/existing'
+      });
+      expect(result.profile.fallback?.['sdd-orchestrator']).toBeUndefined();
+    });
+
+    it('fills primary and fallback assignments for sparse profiles without models or fallback maps', () => {
+      const result = assignModelToUnassignedProfilePhases(
+        {} as ProfileData,
+        ['sdd-init', 'sdd-apply', 'sdd-orchestrator', 'sdd-init-fallback', 'not-sdd'],
+        'provider/model'
+      );
+
+      expect(result.modelsAssigned).toBe(3);
+      expect(result.fallbackAssigned).toBe(2);
+      expect(result.profile).toEqual({
+        models: {
+          'sdd-init': 'provider/model',
+          'sdd-apply': 'provider/model',
+          'sdd-orchestrator': 'provider/model'
+        },
+        fallback: {
+          'sdd-init': 'provider/model',
+          'sdd-apply': 'provider/model'
+        }
+      });
+    });
+
+    it('preserves existing non-empty primary and fallback assignments', () => {
+      const profile = {
+        models: {
+          'sdd-init': 'primary/existing',
+          'sdd-apply': 'primary/other'
+        },
+        fallback: {
+          'sdd-init': 'fallback/existing',
+          'sdd-apply': 'fallback/other'
+        }
+      };
+
+      const result = assignModelToUnassignedProfilePhases(
+        profile,
+        ['sdd-init', 'sdd-apply'],
+        'provider/model'
+      );
+
+      expect(result.modelsAssigned).toBe(0);
+      expect(result.fallbackAssigned).toBe(0);
+      expect(result.profile).toEqual(profile);
+    });
+
+    it('ignores non-SDD agents and generated fallback agents and is idempotent', () => {
+      const first = assignModelToUnassignedProfilePhases(
+        { models: {}, fallback: {} },
+        ['sdd-init', 'sdd-init-fallback', 'sdd-orchestrator', 'general-agent'],
+        'provider/model'
+      );
+
+      expect(first.modelsAssigned).toBe(2);
+      expect(first.fallbackAssigned).toBe(1);
+      expect(first.profile.models).toEqual({
+        'sdd-init': 'provider/model',
+        'sdd-orchestrator': 'provider/model'
+      });
+      expect(first.profile.fallback).toEqual({
+        'sdd-init': 'provider/model'
+      });
+
+      const second = assignModelToUnassignedProfilePhases(
+        first.profile,
+        ['sdd-init', 'sdd-init-fallback', 'sdd-orchestrator', 'general-agent'],
+        'provider/model'
+      );
+
+      expect(second.modelsAssigned).toBe(0);
+      expect(second.fallbackAssigned).toBe(0);
+      expect(second.profile).toEqual(first.profile);
+    });
+
+    it('rejects blank model ids without changing profile data', () => {
+      const profile = { models: { 'sdd-init': '' }, fallback: {} };
+
+      expect(() =>
+        assignModelToUnassignedProfilePhases(profile, ['sdd-init'], '   ')
+      ).toThrow('modelId must be a non-empty string');
+      expect(profile.models['sdd-init']).toBe('');
     });
   });
 });

--- a/src/profiles.test.ts
+++ b/src/profiles.test.ts
@@ -576,8 +576,8 @@ describe('profiles logic', () => {
       });
     });
 
-    it('prunes profile versions to the newest 30 snapshots', () => {
-      const existingFiles = Array.from({ length: 31 }, (_, index) => {
+    it('prunes profile versions to the newest 60 snapshots', () => {
+      const existingFiles = Array.from({ length: 61 }, (_, index) => {
         const hour = String(index).padStart(2, '0');
         return `2026-04-26T${hour}-00-00-000Z-${index}.json`;
       });

--- a/src/profiles.test.ts
+++ b/src/profiles.test.ts
@@ -2,11 +2,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as fs from 'node:fs';
 import type { ProfileData } from './types';
 import { BULK_ASSIGNMENT_MODE, BULK_ASSIGNMENT_TARGET, PROFILE_VERSION_SOURCE } from './types';
-import { 
+import { formatProfileVersionPreviewLines } from './dialogs';
+import {
   extractSddAgentModels, 
   extractSddFallbackModels, 
   readProfileModels, 
   readProfileFallbackModels, 
+  sanitizeProfileName,
   syncSddFallbackAgents, 
   validateProfileFallbackMapping,
   isSddProfile,
@@ -20,7 +22,9 @@ import {
   readProfileVersion,
   restoreProfileVersion,
   updateProfileWithBulkPhaseAssignment,
-  updateProfilePhaseModel
+  updateProfilePhaseModel,
+  deleteProfileFile,
+  renameProfileFile
 } from './profiles';
 
 vi.mock('node:fs');
@@ -45,6 +49,20 @@ describe('profiles logic', () => {
       expect(isSddProfile('profile.json')).toBe(true);
       expect(isSddProfile('readme.md')).toBe(false);
       expect(isSddProfile('config')).toBe(false);
+    });
+  });
+
+  describe('sanitizeProfileName', () => {
+    it('accepts safe names and strips a trailing json extension', () => {
+      expect(sanitizeProfileName(' team-default.json ')).toBe('team-default');
+      expect(sanitizeProfileName('team default.v2')).toBe('team default.v2');
+    });
+
+    it('rejects empty, traversal, separators, and unsafe characters', () => {
+      expect(() => sanitizeProfileName('   ')).toThrow('Profile name cannot be empty');
+      expect(() => sanitizeProfileName('../team')).toThrow('unsafe characters');
+      expect(() => sanitizeProfileName('team/nested')).toThrow('unsafe characters');
+      expect(() => sanitizeProfileName('team*prod')).toThrow('unsafe characters');
     });
   });
 
@@ -150,6 +168,48 @@ describe('profiles logic', () => {
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         '/mock/profiles/compatible.json',
         JSON.stringify(profileData, null, 2)
+      );
+    });
+
+    it('writes canonical profile payloads without stale legacy or config-shaped fields', () => {
+      writeProfileData('/mock/profiles/compatible.json', {
+        models: { 'sdd-init': ' gpt-4 ', 'not-sdd': 'ignore-me' } as any,
+        fallback: { 'sdd-init': ' gpt-3.5 ', 'invalid': 'ignore-me' } as any,
+        description: 'team defaults',
+        agent: { 'sdd-init': { model: 'stale/model' } },
+        'sdd-init': 'legacy/model',
+      } as any);
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/mock/profiles/compatible.json',
+        JSON.stringify({
+          description: 'team defaults',
+          models: { 'sdd-init': 'gpt-4' },
+          fallback: { 'sdd-init': 'gpt-3.5' }
+        }, null, 2)
+      );
+    });
+
+    it('omits empty fallback maps when reading and writing full profile data', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        models: { 'sdd-init': 'gpt-4' },
+        fallback: {},
+        description: 'team defaults'
+      }));
+
+      const profileData = readProfileData('/mock/profiles/compatible.json');
+      writeProfileData('/mock/profiles/compatible.json', profileData);
+
+      expect(profileData).toEqual({
+        models: { 'sdd-init': 'gpt-4' },
+        description: 'team defaults'
+      });
+      expect(fs.writeFileSync).toHaveBeenLastCalledWith(
+        '/mock/profiles/compatible.json',
+        JSON.stringify({
+          description: 'team defaults',
+          models: { 'sdd-init': 'gpt-4' }
+        }, null, 2)
       );
     });
   });
@@ -613,7 +673,100 @@ describe('profiles logic', () => {
       expect(() => readProfileVersion('../evil.json')).toThrow('Invalid profile version id');
     });
 
-    it('restores only the selected profile from version raw content', () => {
+    it('skips corrupt version files instead of failing the entire list', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        '2026-04-26T10-00-00-000Z-good.json',
+        '2026-04-26T11-00-00-000Z-bad.json',
+      ] as any);
+      vi.mocked(fs.readFileSync).mockImplementation((filePath: any) => {
+        if (String(filePath).includes('bad.json')) {
+          return '{invalid json';
+        }
+
+        return JSON.stringify({
+          version: 1,
+          id: 'team.json/2026-04-26T10-00-00-000Z-good.json',
+          profileFile: 'team.json',
+          createdAt: '2026-04-26T10:00:00.000Z',
+          operation,
+          operationSummary: 'Bulk fill both',
+          beforeRaw: '{"models":{"sdd-init":"old"}}',
+          preview: { models: { 'sdd-init': 'old' }, fallback: {} }
+        });
+      });
+
+      expect(listProfileVersions('team.json')).toEqual([
+        {
+          version: 1,
+          id: 'team.json/2026-04-26T10-00-00-000Z-good.json',
+          profileFile: 'team.json',
+          createdAt: '2026-04-26T10:00:00.000Z',
+          source: PROFILE_VERSION_SOURCE.BULK,
+          operation: {
+            source: PROFILE_VERSION_SOURCE.BULK,
+            target: BULK_ASSIGNMENT_TARGET.BOTH,
+            mode: BULK_ASSIGNMENT_MODE.FILL_ONLY,
+          },
+          operationSummary: 'Bulk fill both',
+          preview: { models: { 'sdd-init': 'old' }, fallback: {} }
+        }
+      ]);
+    });
+
+    it('rejects malformed parseable version payloads and skips them from lists', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        '2026-04-26T10-00-00-000Z-good.json',
+        '2026-04-26T11-00-00-000Z-malformed.json',
+      ] as any);
+      vi.mocked(fs.readFileSync).mockImplementation((filePath: any) => {
+        if (String(filePath).includes('malformed.json')) {
+          return JSON.stringify({
+            version: 1,
+            id: 'team.json/2026-04-26T11-00-00-000Z-malformed.json',
+            profileFile: 'team.json',
+            createdAt: null,
+            source: PROFILE_VERSION_SOURCE.BULK,
+            operation,
+            operationSummary: 'Bulk fill both',
+            beforeRaw: null,
+            preview: null,
+          });
+        }
+
+        return JSON.stringify({
+          version: 1,
+          id: 'team.json/2026-04-26T10-00-00-000Z-good.json',
+          profileFile: 'team.json',
+          createdAt: '2026-04-26T10:00:00.000Z',
+          operation,
+          operationSummary: 'Bulk fill both',
+          beforeRaw: '{"models":{"sdd-init":"old"}}',
+          preview: { models: { 'sdd-init': 'old' }, fallback: {} }
+        });
+      });
+
+      expect(() => readProfileVersion('team.json/2026-04-26T11-00-00-000Z-malformed.json')).toThrow('Invalid profile version data');
+      expect(listProfileVersions('team.json')).toEqual([
+        {
+          version: 1,
+          id: 'team.json/2026-04-26T10-00-00-000Z-good.json',
+          profileFile: 'team.json',
+          createdAt: '2026-04-26T10:00:00.000Z',
+          source: PROFILE_VERSION_SOURCE.BULK,
+          operation: {
+            source: PROFILE_VERSION_SOURCE.BULK,
+            target: BULK_ASSIGNMENT_TARGET.BOTH,
+            mode: BULK_ASSIGNMENT_MODE.FILL_ONLY,
+          },
+          operationSummary: 'Bulk fill both',
+          preview: { models: { 'sdd-init': 'old' }, fallback: {} }
+        }
+      ]);
+    });
+
+    it('sanitizes preview maps for valid persisted versions so preview formatting stays safe', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         version: 1,
@@ -622,15 +775,122 @@ describe('profiles logic', () => {
         createdAt: '2026-04-26T10:00:00.000Z',
         operation,
         operationSummary: 'Bulk fill both',
-        beforeRaw: '{"models":{"sdd-init":"old/model"}}',
-        preview: { models: { 'sdd-init': 'old/model' }, fallback: {} }
+        beforeRaw: '{"models":{"sdd-init":"old"}}',
+        preview: {
+          models: { 'sdd-init': 'old', 'sdd-apply': 42, random: 'ignored' },
+          fallback: { 'sdd-init': 'fallback', 'sdd-design': null, random: 'ignored' }
+        }
       }));
+
+      const version = readProfileVersion('team.json/2026-04-26T10-00-00-000Z-a.json');
+
+      expect(version.preview).toEqual({
+        models: { 'sdd-init': 'old' },
+        fallback: { 'sdd-init': 'fallback' }
+      });
+      expect(() => formatProfileVersionPreviewLines(version)).not.toThrow();
+    });
+
+    it('restores only the selected profile from version raw content after snapshotting the live profile', () => {
+      const writes: Array<{ filePath: string; content: string }> = [];
+      vi.mocked(fs.existsSync).mockImplementation((filePath: any) => String(filePath).includes('/profile-versions/team.json'));
+      vi.mocked(fs.readdirSync).mockReturnValue([] as any);
+      vi.mocked(fs.readFileSync).mockImplementation((filePath: any) => {
+        if (String(filePath).includes('/profile-versions/team.json/')) {
+          return JSON.stringify({
+            version: 1,
+            id: 'team.json/2026-04-26T10-00-00-000Z-a.json',
+            profileFile: 'team.json',
+            createdAt: '2026-04-26T10:00:00.000Z',
+            operation,
+            operationSummary: 'Bulk fill both',
+            beforeRaw: '{"models":{"sdd-init":"old/model"}}',
+            preview: { models: { 'sdd-init': 'old/model' }, fallback: {} }
+          });
+        }
+
+        return '{"models":{"sdd-init":"live/model"}}';
+      });
+      vi.mocked(fs.writeFileSync).mockImplementation((filePath: any, content: any) => {
+        writes.push({ filePath: String(filePath), content: String(content) });
+      });
 
       const restored = restoreProfileVersion('team.json', 'team.json/2026-04-26T10-00-00-000Z-a.json');
 
       expect(restored.profileFile).toBe('team.json');
-      expect(fs.writeFileSync).toHaveBeenCalledWith('/mock/profiles/team.json', '{"models":{"sdd-init":"old/model"}}');
+      expect(writes[0].filePath).toContain('/mock/config/profile-versions/team.json/');
+      expect(writes[0].content).toContain('Snapshot before restoring 2026-04-26T10-00-00-000Z-a.json');
+      expect(writes[0].content).toContain('live/model');
+      expect(writes[1]).toEqual({
+        filePath: '/mock/profiles/team.json',
+        content: '{"models":{"sdd-init":"old/model"}}'
+      });
       expect(() => restoreProfileVersion('other.json', 'team.json/2026-04-26T10-00-00-000Z-a.json')).toThrow('does not match selected profile');
+    });
+
+    it('restores a valid selected version even when the current live profile JSON is corrupt', () => {
+      const writes: Array<{ filePath: string; content: string }> = [];
+      vi.mocked(fs.existsSync).mockImplementation((filePath: any) => String(filePath).includes('/profile-versions/team.json'));
+      vi.mocked(fs.readdirSync).mockReturnValue([] as any);
+      vi.mocked(fs.readFileSync).mockImplementation((filePath: any) => {
+        if (String(filePath).includes('/profile-versions/team.json/')) {
+          return JSON.stringify({
+            version: 1,
+            id: 'team.json/2026-04-26T10-00-00-000Z-a.json',
+            profileFile: 'team.json',
+            createdAt: '2026-04-26T10:00:00.000Z',
+            operation,
+            operationSummary: 'Bulk fill both',
+            beforeRaw: '{"models":{"sdd-init":"old/model"}}',
+            preview: { models: { 'sdd-init': 'old/model' }, fallback: {} }
+          });
+        }
+
+        return '{invalid current profile';
+      });
+      vi.mocked(fs.writeFileSync).mockImplementation((filePath: any, content: any) => {
+        writes.push({ filePath: String(filePath), content: String(content) });
+      });
+
+      expect(() => restoreProfileVersion('team.json', 'team.json/2026-04-26T10-00-00-000Z-a.json')).not.toThrow();
+      expect(writes[0].filePath).toContain('/mock/config/profile-versions/team.json/');
+      expect(writes[0].content).toContain('"beforeRaw": "{invalid current profile"');
+      expect(writes[0].content).toContain('"preview": {\n    "models": {},\n    "fallback": {}\n  }');
+      expect(writes[1]).toEqual({
+        filePath: '/mock/profiles/team.json',
+        content: '{"models":{"sdd-init":"old/model"}}'
+      });
+    });
+
+    it('restores raw snapshot content even when beforeRaw is invalid JSON', () => {
+      const writes: Array<{ filePath: string; content: string }> = [];
+      vi.mocked(fs.existsSync).mockImplementation((filePath: any) => String(filePath).includes('/profile-versions/team.json'));
+      vi.mocked(fs.readdirSync).mockReturnValue([] as any);
+      vi.mocked(fs.readFileSync).mockImplementation((filePath: any) => {
+        if (String(filePath).includes('/profile-versions/team.json/')) {
+          return JSON.stringify({
+            version: 1,
+            id: 'team.json/2026-04-26T10-00-00-000Z-a.json',
+            profileFile: 'team.json',
+            createdAt: '2026-04-26T10:00:00.000Z',
+            operation,
+            operationSummary: 'Bulk fill both',
+            beforeRaw: '{invalid snapshot payload',
+            preview: { models: {}, fallback: {} }
+          });
+        }
+
+        return '{"models":{"sdd-init":"live/model"}}';
+      });
+      vi.mocked(fs.writeFileSync).mockImplementation((filePath: any, content: any) => {
+        writes.push({ filePath: String(filePath), content: String(content) });
+      });
+
+      expect(() => restoreProfileVersion('team.json', 'team.json/2026-04-26T10-00-00-000Z-a.json')).not.toThrow();
+      expect(writes[1]).toEqual({
+        filePath: '/mock/profiles/team.json',
+        content: '{invalid snapshot payload'
+      });
     });
 
     it('creates a version before mutating bulk write and skips versioning for no-op or validation failure', () => {
@@ -745,6 +1005,302 @@ describe('profiles logic', () => {
       expect(primaryNoOp.changed).toBe(false);
       expect(fallbackNoOp.changed).toBe(false);
       expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('renames matching profile version history with migrated snapshot metadata', () => {
+      const files: Record<string, string> = {
+        '/mock/profiles/old.json': '{"models":{"sdd-init":"live/model"}}',
+        '/mock/config/profile-versions/old.json/2026-04-26T10-00-00-000Z-a.json': JSON.stringify({
+          version: 1,
+          id: 'old.json/2026-04-26T10-00-00-000Z-a.json',
+          profileFile: 'old.json',
+          createdAt: '2026-04-26T10:00:00.000Z',
+          operation,
+          operationSummary: 'Bulk fill both',
+          beforeRaw: '{"models":{"sdd-init":"old/model"}}',
+          preview: { models: { 'sdd-init': 'old/model' }, fallback: {} }
+        })
+      };
+
+      vi.mocked(fs.existsSync).mockImplementation((filePath: any) => {
+        const target = String(filePath);
+        if (target in files) return true;
+        return Object.keys(files).some((existingPath) => existingPath.startsWith(`${target}/`));
+      });
+      vi.mocked(fs.readdirSync).mockImplementation((dirPath: any) => {
+        const target = `${String(dirPath)}/`;
+        return Object.keys(files)
+          .filter((filePath) => filePath.startsWith(target))
+          .map((filePath) => filePath.slice(target.length))
+          .filter((entry) => !entry.includes('/')) as any;
+      });
+      vi.mocked(fs.readFileSync).mockImplementation((filePath: any) => files[String(filePath)]);
+      vi.mocked(fs.writeFileSync).mockImplementation((filePath: any, content: any) => {
+        files[String(filePath)] = String(content);
+      });
+      vi.mocked(fs.renameSync).mockImplementation((fromPath: any, toPath: any) => {
+        const from = String(fromPath);
+        const to = String(toPath);
+
+        if (from in files) {
+          files[to] = files[from];
+          delete files[from];
+          return;
+        }
+
+        const prefix = `${from}/`;
+        for (const filePath of Object.keys(files)) {
+          if (!filePath.startsWith(prefix)) continue;
+          const nextPath = `${to}/${filePath.slice(prefix.length)}`;
+          files[nextPath] = files[filePath];
+          delete files[filePath];
+        }
+      });
+
+      renameProfileFile('old.json', 'new.json');
+
+      const versions = listProfileVersions('new.json');
+      const read = readProfileVersion('new.json/2026-04-26T10-00-00-000Z-a.json');
+
+      expect(versions).toEqual([
+        {
+          version: 1,
+          id: 'new.json/2026-04-26T10-00-00-000Z-a.json',
+          profileFile: 'new.json',
+          createdAt: '2026-04-26T10:00:00.000Z',
+          source: PROFILE_VERSION_SOURCE.BULK,
+          operation: {
+            source: PROFILE_VERSION_SOURCE.BULK,
+            target: BULK_ASSIGNMENT_TARGET.BOTH,
+            mode: BULK_ASSIGNMENT_MODE.FILL_ONLY,
+          },
+          operationSummary: 'Bulk fill both',
+          preview: { models: { 'sdd-init': 'old/model' }, fallback: {} }
+        }
+      ]);
+      expect(read.id).toBe('new.json/2026-04-26T10-00-00-000Z-a.json');
+      expect(read.profileFile).toBe('new.json');
+      expect(fs.renameSync).toHaveBeenCalledWith('/mock/profiles/old.json', '/mock/profiles/new.json');
+      expect(fs.renameSync).toHaveBeenCalledWith('/mock/config/profile-versions/old.json', '/mock/config/profile-versions/new.json');
+    });
+
+    it('renames the profile and preserves corrupt version files without blocking valid snapshot migration', () => {
+      const files: Record<string, string> = {
+        '/mock/profiles/old.json': '{"models":{"sdd-init":"live/model"}}',
+        '/mock/config/profile-versions/old.json/2026-04-26T10-00-00-000Z-good.json': JSON.stringify({
+          version: 1,
+          id: 'old.json/2026-04-26T10-00-00-000Z-good.json',
+          profileFile: 'old.json',
+          createdAt: '2026-04-26T10:00:00.000Z',
+          operation,
+          operationSummary: 'Bulk fill both',
+          beforeRaw: '{"models":{"sdd-init":"old/model"}}',
+          preview: { models: { 'sdd-init': 'old/model' }, fallback: {} }
+        }),
+        '/mock/config/profile-versions/old.json/2026-04-26T11-00-00-000Z-bad.json': '{invalid json'
+      };
+
+      vi.mocked(fs.existsSync).mockImplementation((filePath: any) => {
+        const target = String(filePath);
+        if (target in files) return true;
+        return Object.keys(files).some((existingPath) => existingPath.startsWith(`${target}/`));
+      });
+      vi.mocked(fs.readdirSync).mockImplementation((dirPath: any) => {
+        const target = `${String(dirPath)}/`;
+        return Object.keys(files)
+          .filter((filePath) => filePath.startsWith(target))
+          .map((filePath) => filePath.slice(target.length))
+          .filter((entry) => !entry.includes('/')) as any;
+      });
+      vi.mocked(fs.readFileSync).mockImplementation((filePath: any) => files[String(filePath)]);
+      vi.mocked(fs.writeFileSync).mockImplementation((filePath: any, content: any) => {
+        files[String(filePath)] = String(content);
+      });
+      vi.mocked(fs.renameSync).mockImplementation((fromPath: any, toPath: any) => {
+        const from = String(fromPath);
+        const to = String(toPath);
+
+        if (from in files) {
+          files[to] = files[from];
+          delete files[from];
+          return;
+        }
+
+        const prefix = `${from}/`;
+        for (const filePath of Object.keys(files)) {
+          if (!filePath.startsWith(prefix)) continue;
+          const nextPath = `${to}/${filePath.slice(prefix.length)}`;
+          files[nextPath] = files[filePath];
+          delete files[filePath];
+        }
+      });
+
+      renameProfileFile('old.json', 'new.json');
+
+      expect(listProfileVersions('new.json')).toEqual([
+        {
+          version: 1,
+          id: 'new.json/2026-04-26T10-00-00-000Z-good.json',
+          profileFile: 'new.json',
+          createdAt: '2026-04-26T10:00:00.000Z',
+          source: PROFILE_VERSION_SOURCE.BULK,
+          operation: {
+            source: PROFILE_VERSION_SOURCE.BULK,
+            target: BULK_ASSIGNMENT_TARGET.BOTH,
+            mode: BULK_ASSIGNMENT_MODE.FILL_ONLY,
+          },
+          operationSummary: 'Bulk fill both',
+          preview: { models: { 'sdd-init': 'old/model' }, fallback: {} }
+        }
+      ]);
+      expect(files['/mock/config/profile-versions/new.json/2026-04-26T11-00-00-000Z-bad.json']).toBe('{invalid json');
+      expect(files['/mock/config/profile-versions/new.json/2026-04-26T10-00-00-000Z-good.json']).toContain('"id": "new.json/2026-04-26T10-00-00-000Z-good.json"');
+    });
+
+    it('rolls back the profile rename if version history rename fails', () => {
+      const files: Record<string, string> = {
+        '/mock/profiles/old.json': '{"models":{"sdd-init":"live/model"}}',
+        '/mock/config/profile-versions/old.json/2026-04-26T10-00-00-000Z-a.json': JSON.stringify({
+          version: 1,
+          id: 'old.json/2026-04-26T10-00-00-000Z-a.json',
+          profileFile: 'old.json',
+          createdAt: '2026-04-26T10:00:00.000Z',
+          operation,
+          operationSummary: 'Bulk fill both',
+          beforeRaw: '{"models":{"sdd-init":"old/model"}}',
+          preview: { models: { 'sdd-init': 'old/model' }, fallback: {} }
+        })
+      };
+
+      vi.mocked(fs.existsSync).mockImplementation((filePath: any) => {
+        const target = String(filePath);
+        if (target in files) return true;
+        return Object.keys(files).some((existingPath) => existingPath.startsWith(`${target}/`));
+      });
+      vi.mocked(fs.readdirSync).mockImplementation((dirPath: any) => {
+        const target = `${String(dirPath)}/`;
+        return Object.keys(files)
+          .filter((filePath) => filePath.startsWith(target))
+          .map((filePath) => filePath.slice(target.length))
+          .filter((entry) => !entry.includes('/')) as any;
+      });
+      vi.mocked(fs.readFileSync).mockImplementation((filePath: any) => files[String(filePath)]);
+      vi.mocked(fs.writeFileSync).mockImplementation((filePath: any, content: any) => {
+        files[String(filePath)] = String(content);
+      });
+      vi.mocked(fs.renameSync).mockImplementation((fromPath: any, toPath: any) => {
+        const from = String(fromPath);
+        const to = String(toPath);
+
+        if (from === '/mock/config/profile-versions/old.json' && to === '/mock/config/profile-versions/new.json') {
+          throw new Error('version rename failed');
+        }
+
+        if (from in files) {
+          files[to] = files[from];
+          delete files[from];
+          return;
+        }
+
+        const prefix = `${from}/`;
+        for (const filePath of Object.keys(files)) {
+          if (!filePath.startsWith(prefix)) continue;
+          const nextPath = `${to}/${filePath.slice(prefix.length)}`;
+          files[nextPath] = files[filePath];
+          delete files[filePath];
+        }
+      });
+
+      expect(() => renameProfileFile('old.json', 'new.json')).toThrow('version rename failed');
+      expect(files['/mock/profiles/old.json']).toBe('{"models":{"sdd-init":"live/model"}}');
+      expect(files['/mock/profiles/new.json']).toBeUndefined();
+    });
+
+    it('rolls back rewritten version metadata if migration fails mid-rewrite', () => {
+      const files: Record<string, string> = {
+        '/mock/profiles/old.json': '{"models":{"sdd-init":"live/model"}}',
+        '/mock/config/profile-versions/old.json/2026-04-26T10-00-00-000Z-a.json': JSON.stringify({
+          version: 1,
+          id: 'old.json/2026-04-26T10-00-00-000Z-a.json',
+          profileFile: 'old.json',
+          createdAt: '2026-04-26T10:00:00.000Z',
+          operation,
+          operationSummary: 'Bulk fill both',
+          beforeRaw: '{"models":{"sdd-init":"old/model"}}',
+          preview: { models: { 'sdd-init': 'old/model' }, fallback: {} }
+        }),
+        '/mock/config/profile-versions/old.json/2026-04-26T11-00-00-000Z-b.json': JSON.stringify({
+          version: 1,
+          id: 'old.json/2026-04-26T11-00-00-000Z-b.json',
+          profileFile: 'old.json',
+          createdAt: '2026-04-26T11:00:00.000Z',
+          operation,
+          operationSummary: 'Bulk fill both again',
+          beforeRaw: '{"models":{"sdd-init":"older/model"}}',
+          preview: { models: { 'sdd-init': 'older/model' }, fallback: {} }
+        })
+      };
+
+      vi.mocked(fs.existsSync).mockImplementation((filePath: any) => {
+        const target = String(filePath);
+        if (target in files) return true;
+        return Object.keys(files).some((existingPath) => existingPath.startsWith(`${target}/`));
+      });
+      vi.mocked(fs.readdirSync).mockImplementation((dirPath: any) => {
+        const target = `${String(dirPath)}/`;
+        return Object.keys(files)
+          .filter((filePath) => filePath.startsWith(target))
+          .map((filePath) => filePath.slice(target.length))
+          .filter((entry) => !entry.includes('/')) as any;
+      });
+      vi.mocked(fs.readFileSync).mockImplementation((filePath: any) => files[String(filePath)]);
+      vi.mocked(fs.writeFileSync).mockImplementation((filePath: any, content: any) => {
+        files[String(filePath)] = String(content);
+      });
+      vi.mocked(fs.renameSync).mockImplementation((fromPath: any, toPath: any) => {
+        const from = String(fromPath);
+        const to = String(toPath);
+
+        if (from.includes('2026-04-26T11-00-00-000Z-b.json.tmp-') && to.endsWith('/2026-04-26T11-00-00-000Z-b.json')) {
+          throw new Error('version rewrite failed');
+        }
+
+        if (from in files) {
+          files[to] = files[from];
+          delete files[from];
+          return;
+        }
+
+        const prefix = `${from}/`;
+        for (const filePath of Object.keys(files)) {
+          if (!filePath.startsWith(prefix)) continue;
+          const nextPath = `${to}/${filePath.slice(prefix.length)}`;
+          files[nextPath] = files[filePath];
+          delete files[filePath];
+        }
+      });
+
+      expect(() => renameProfileFile('old.json', 'new.json')).toThrow('version rewrite failed');
+      expect(files['/mock/profiles/old.json']).toBe('{"models":{"sdd-init":"live/model"}}');
+      expect(files['/mock/profiles/new.json']).toBeUndefined();
+
+      const firstVersion = readProfileVersion('old.json/2026-04-26T10-00-00-000Z-a.json');
+      const secondVersion = readProfileVersion('old.json/2026-04-26T11-00-00-000Z-b.json');
+
+      expect(firstVersion.id).toBe('old.json/2026-04-26T10-00-00-000Z-a.json');
+      expect(firstVersion.profileFile).toBe('old.json');
+      expect(secondVersion.id).toBe('old.json/2026-04-26T11-00-00-000Z-b.json');
+      expect(secondVersion.profileFile).toBe('old.json');
+      expect(files['/mock/config/profile-versions/new.json/2026-04-26T10-00-00-000Z-a.json']).toBeUndefined();
+    });
+
+    it('deletes matching profile version history with the profile file', () => {
+      vi.mocked(fs.existsSync).mockImplementation((filePath: any) => String(filePath) === '/mock/config/profile-versions/team.json');
+
+      deleteProfileFile('team.json');
+
+      expect(fs.unlinkSync).toHaveBeenCalledWith('/mock/profiles/team.json');
+      expect(fs.rmSync).toHaveBeenCalledWith('/mock/config/profile-versions/team.json', { recursive: true, force: true });
     });
   });
 });

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -38,6 +38,7 @@ import { resolvePaths, ensureProfilesDir } from "./config";
 
 const PROFILE_VERSION_FORMAT = 1;
 const DEFAULT_PROFILE_VERSION_RETENTION = 60;
+const PROFILE_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._ -]*$/;
 
 function isUnassignedProfileValue(value: unknown): boolean {
   return typeof value !== "string" || value.trim().length === 0;
@@ -51,6 +52,29 @@ function isUnassignedProfileValue(value: unknown): boolean {
  */
 export function isSddProfile(fileName: string): boolean {
   return fileName.endsWith(".json");
+}
+
+export function sanitizeProfileName(profileName: string): string {
+  const trimmed = profileName?.trim();
+  if (!trimmed) {
+    throw new Error("Profile name cannot be empty");
+  }
+
+  const baseName = trimmed.replace(/\.json$/i, "");
+  if (!baseName || baseName === "." || baseName === "..") {
+    throw new Error("Profile name is invalid");
+  }
+
+  if (
+    baseName.includes("/") ||
+    baseName.includes("\\") ||
+    baseName.includes("..") ||
+    !PROFILE_NAME_PATTERN.test(baseName)
+  ) {
+    throw new Error("Profile name contains unsafe characters");
+  }
+
+  return baseName;
 }
 
 /**
@@ -87,8 +111,41 @@ export function extractSddFallbackModels(raw: any): ProfileFallbackModels {
   return Object.fromEntries(
     Object.entries(source).filter(
       ([name, value]: any) => isFallbackEligibleSddAgent(name) && typeof value === "string" && value.trim()
-    )
+    ).map(([name, value]: any) => [name, value.trim()])
   );
+}
+
+function normalizeProfileModels(models: unknown): ProfileModels {
+  if (!models || typeof models !== "object" || Array.isArray(models)) return {};
+
+  return Object.fromEntries(
+    Object.entries(models)
+      .filter(([name, value]: any) => isPrimarySddAgent(name) && typeof value === "string" && value.trim())
+      .map(([name, value]: any) => [name, value.trim()])
+  );
+}
+
+function extractPersistedProfileExtras(raw: unknown): Record<string, unknown> {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+
+  return Object.fromEntries(
+    Object.entries(raw).filter(([key]) => {
+      if (key === "models" || key === "fallback" || key === "agent") return false;
+      if (isPrimarySddAgent(key) || isSddFallbackAgent(key)) return false;
+      return true;
+    })
+  );
+}
+
+function normalizePersistedProfileData(profile: ProfileData): ProfileData {
+  const models = normalizeProfileModels(profile?.models);
+  const fallback = extractSddFallbackModels({ fallback: profile?.fallback || {} });
+
+  return {
+    ...extractPersistedProfileExtras(profile),
+    models,
+    ...(Object.keys(fallback).length > 0 ? { fallback } : {}),
+  };
 }
 
 /**
@@ -144,10 +201,13 @@ export function readProfileFallbackModels(profilePath: string): ProfileFallbackM
  */
 export function readProfileData(profilePath: string): ProfileData {
   const raw = JSON.parse(fs.readFileSync(profilePath, "utf-8"));
+  const fallback = readProfileFallbackModels(profilePath);
   return {
-    ...(raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {}),
+    ...extractPersistedProfileExtras(raw),
     models: readProfileModels(profilePath),
-    fallback: readProfileFallbackModels(profilePath),
+    ...(Object.keys(fallback).length > 0
+      ? { fallback }
+      : {}),
   };
 }
 
@@ -155,7 +215,7 @@ export function readProfileData(profilePath: string): ProfileData {
  * Persists full profile data while preserving the existing profile payload shape.
  */
 export function writeProfileData(profilePath: string, profile: ProfileData): void {
-  fs.writeFileSync(profilePath, JSON.stringify(profile, null, 2));
+  fs.writeFileSync(profilePath, JSON.stringify(normalizePersistedProfileData(profile), null, 2));
 }
 
 function normalizePrimarySddAgentNames(primarySddAgentNames: string[]): string[] {
@@ -210,6 +270,32 @@ function atomicWriteFile(filePath: string, content: string): void {
   fs.renameSync(tmpPath, filePath);
 }
 
+function buildEmptyProfilePreview(): { models: ProfileModels; fallback: ProfileFallbackModels } {
+  return { models: {}, fallback: {} };
+}
+
+function buildRenamedProfileVersion(versionFile: string, versionRaw: string, oldProfileFile: string, newProfileFile: string): ProfileVersion {
+  const oldVersionId = `${oldProfileFile}/${versionFile}`;
+  const newVersionId = `${newProfileFile}/${versionFile}`;
+  const parsed = JSON.parse(versionRaw);
+  if (
+    parsed?.version !== PROFILE_VERSION_FORMAT ||
+    parsed?.id !== oldVersionId ||
+    parsed?.profileFile !== oldProfileFile
+  ) {
+    throw new Error("Invalid profile version data");
+  }
+
+  return normalizeProfileVersion(
+    {
+      ...parsed,
+      id: newVersionId,
+      profileFile: newProfileFile,
+    },
+    newVersionId
+  );
+}
+
 function buildOperationSummary(operation: BulkAssignmentOperation, modelsAssigned: number, fallbackAssigned: number): string {
   const action = operation.mode === BULK_ASSIGNMENT_MODE.OVERWRITE ? "Override" : "Set";
   const target = operation.target === BULK_ASSIGNMENT_TARGET.BOTH
@@ -231,6 +317,88 @@ function normalizeBulkVersionOperation(
   };
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function sanitizeStringRecord(value: unknown): Record<string, string> | null {
+  if (!isRecord(value)) return null;
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([, entryValue]) => typeof entryValue === "string")
+      .map(([key, entryValue]) => [key, entryValue.trim()])
+  );
+}
+
+function normalizePersistedBulkVersionOperation(operation: unknown): BulkProfileVersionOperation | null {
+  if (!isRecord(operation)) return null;
+  if (
+    operation.target !== BULK_ASSIGNMENT_TARGET.PRIMARY &&
+    operation.target !== BULK_ASSIGNMENT_TARGET.FALLBACK &&
+    operation.target !== BULK_ASSIGNMENT_TARGET.BOTH
+  ) {
+    return null;
+  }
+  if (
+    operation.mode !== BULK_ASSIGNMENT_MODE.FILL_ONLY &&
+    operation.mode !== BULK_ASSIGNMENT_MODE.OVERWRITE
+  ) {
+    return null;
+  }
+
+  return normalizeBulkVersionOperation(
+    {
+      target: operation.target,
+      mode: operation.mode,
+    },
+    typeof operation.changedPhases === "number" ? operation.changedPhases : undefined
+  );
+}
+
+function normalizePersistedPhaseVersionOperation(operation: unknown): PhaseProfileVersionOperation | null {
+  if (!isRecord(operation)) return null;
+  if (!isPrimarySddAgent(operation.phase) || isSddFallbackAgent(operation.phase)) return null;
+  if (
+    operation.field !== PROFILE_PHASE_MODEL_FIELD.PRIMARY &&
+    operation.field !== PROFILE_PHASE_MODEL_FIELD.FALLBACK
+  ) {
+    return null;
+  }
+  if (typeof operation.modelId !== "string" || !operation.modelId.trim()) return null;
+
+  return {
+    source: PROFILE_VERSION_SOURCE.PHASE,
+    phase: operation.phase,
+    field: operation.field,
+    modelId: operation.modelId.trim(),
+    changedPhases: 1,
+  };
+}
+
+function normalizePersistedProfileVersionOperation(
+  source: unknown,
+  operation: unknown
+): ProfileVersionOperation | null {
+  if (source === PROFILE_VERSION_SOURCE.PHASE) {
+    return normalizePersistedPhaseVersionOperation(operation);
+  }
+  return normalizePersistedBulkVersionOperation(operation);
+}
+
+function normalizePersistedProfileVersionPreview(preview: unknown): ProfileVersion["preview"] | null {
+  if (!isRecord(preview)) return null;
+
+  const models = sanitizeStringRecord(preview.models);
+  const fallback = sanitizeStringRecord(preview.fallback);
+  if (!models || !fallback) return null;
+
+  return {
+    models: normalizeProfileModels(models),
+    fallback: extractSddFallbackModels({ fallback }),
+  };
+}
+
 function normalizeProfileVersionOperation(operation: BulkAssignmentOperation | ProfileVersionOperation): ProfileVersionOperation {
   if ((operation as ProfileVersionOperation).source === PROFILE_VERSION_SOURCE.PHASE) {
     return operation as PhaseProfileVersionOperation;
@@ -238,14 +406,41 @@ function normalizeProfileVersionOperation(operation: BulkAssignmentOperation | P
   return normalizeBulkVersionOperation(operation as BulkAssignmentOperation | BulkProfileVersionOperation);
 }
 
-function normalizeProfileVersion(parsed: any, versionId: string): ProfileVersion {
-  const operation = normalizeProfileVersionOperation(parsed.operation || {});
-  const source = parsed.source === PROFILE_VERSION_SOURCE.PHASE ? PROFILE_VERSION_SOURCE.PHASE : PROFILE_VERSION_SOURCE.BULK;
+function normalizeProfileVersion(parsed: unknown, versionId: string): ProfileVersion {
+  if (!isRecord(parsed)) {
+    throw new Error("Invalid profile version data");
+  }
+
+  const source = parsed.source === undefined
+    ? PROFILE_VERSION_SOURCE.BULK
+    : parsed.source === PROFILE_VERSION_SOURCE.BULK || parsed.source === PROFILE_VERSION_SOURCE.PHASE
+      ? parsed.source
+      : null;
+  const operation = normalizePersistedProfileVersionOperation(source, parsed.operation);
+  const preview = normalizePersistedProfileVersionPreview(parsed.preview);
+  if (
+    parsed.version !== PROFILE_VERSION_FORMAT ||
+    parsed.id !== versionId ||
+    parsed.profileFile !== parseVersionId(versionId).profileFile ||
+    typeof parsed.createdAt !== "string" ||
+    typeof parsed.operationSummary !== "string" ||
+    typeof parsed.beforeRaw !== "string" ||
+    !source ||
+    !operation ||
+    !preview
+  ) {
+    throw new Error("Invalid profile version data");
+  }
+
   return {
     ...parsed,
     source,
     operation,
     id: versionId,
+    createdAt: parsed.createdAt,
+    operationSummary: parsed.operationSummary,
+    beforeRaw: parsed.beforeRaw,
+    preview,
   };
 }
 
@@ -254,17 +449,21 @@ function buildPhaseOperationSummary(agentName: string, field: ProfilePhaseModelF
 }
 
 function readProfilePreviewFromRaw(beforeRaw: string): { models: ProfileModels; fallback: ProfileFallbackModels } {
-  const raw = JSON.parse(beforeRaw);
-  return {
-    models: raw && typeof raw === "object" && !Array.isArray(raw)
-      ? raw.models && typeof raw.models === "object" && !Array.isArray(raw.models)
-        ? Object.fromEntries(
-            Object.entries(raw.models).filter(([name, value]: any) => isPrimarySddAgent(name) && typeof value === "string")
-          )
-        : extractSddAgentModels(raw)
-      : {},
-    fallback: extractSddFallbackModels(raw),
-  };
+  try {
+    const raw = JSON.parse(beforeRaw);
+    return {
+      models: raw && typeof raw === "object" && !Array.isArray(raw)
+        ? raw.models && typeof raw.models === "object" && !Array.isArray(raw.models)
+          ? Object.fromEntries(
+              Object.entries(raw.models).filter(([name, value]: any) => isPrimarySddAgent(name) && typeof value === "string")
+            )
+          : extractSddAgentModels(raw)
+        : {},
+      fallback: extractSddFallbackModels(raw),
+    };
+  } catch {
+    return buildEmptyProfilePreview();
+  }
 }
 
 /**
@@ -395,7 +594,14 @@ export function listProfileVersions(profilePathOrFile: string): ProfileVersionMe
 
   return fs.readdirSync(versionDir)
     .filter((file) => String(file).endsWith(".json"))
-    .map((file) => readProfileVersion(`${profileFile}/${file}`))
+    .map((file) => {
+      try {
+        return readProfileVersion(`${profileFile}/${file}`);
+      } catch {
+        return null;
+      }
+    })
+    .filter((version): version is ProfileVersion => Boolean(version))
     .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
     .map(({ beforeRaw, ...metadata }) => metadata);
 }
@@ -406,9 +612,18 @@ export function restoreProfileVersion(profilePathOrFile: string, versionId: stri
   if (version.profileFile !== profileFile) {
     throw new Error("Profile version does not match selected profile");
   }
-  JSON.parse(version.beforeRaw);
   const { profilesDir } = resolvePaths();
-  fs.writeFileSync(path.join(profilesDir, profileFile), version.beforeRaw);
+  const profilePath = path.join(profilesDir, profileFile);
+  createProfileVersion(
+    profilePath,
+    {
+      source: PROFILE_VERSION_SOURCE.BULK,
+      target: BULK_ASSIGNMENT_TARGET.BOTH,
+      mode: BULK_ASSIGNMENT_MODE.OVERWRITE,
+    },
+    `Snapshot before restoring ${path.basename(versionId)}`
+  );
+  fs.writeFileSync(profilePath, version.beforeRaw);
   return version;
 }
 
@@ -493,7 +708,7 @@ export function writeProfileModels(profilePath: string, models: ProfileModels): 
     models,
     ...(Object.keys(fallback).length > 0 ? { fallback } : {}),
   };
-  fs.writeFileSync(profilePath, JSON.stringify(payload, null, 2));
+  writeProfileData(profilePath, payload);
 }
 
 /**
@@ -505,7 +720,7 @@ export function writeProfileFallbackModels(profilePath: string, fallback: Profil
     models,
     ...(Object.keys(fallback).length > 0 ? { fallback } : {}),
   };
-  fs.writeFileSync(profilePath, JSON.stringify(payload, null, 2));
+  writeProfileData(profilePath, payload);
 }
 
 /**
@@ -747,8 +962,14 @@ export function listProfileFiles(): string[] {
  */
 export function deleteProfileFile(fileName: string): void {
   const { profilesDir } = resolvePaths();
-  const profilePath = path.join(profilesDir, fileName);
+  const safeFileName = safeProfileFileName(fileName);
+  const profilePath = path.join(profilesDir, safeFileName);
   fs.unlinkSync(profilePath);
+
+  const versionDir = resolveProfileVersionDir(safeFileName);
+  if (fs.existsSync(versionDir)) {
+    fs.rmSync(versionDir, { recursive: true, force: true });
+  }
 }
 
 /**
@@ -759,7 +980,79 @@ export function deleteProfileFile(fileName: string): void {
  */
 export function renameProfileFile(oldFileName: string, newFileName: string): void {
   const { profilesDir } = resolvePaths();
-  const oldPath = path.join(profilesDir, oldFileName);
-  const newPath = path.join(profilesDir, newFileName);
-  fs.renameSync(oldPath, newPath);
+  const safeOldFileName = safeProfileFileName(oldFileName);
+  const safeNewFileName = safeProfileFileName(newFileName);
+  const oldPath = path.join(profilesDir, safeOldFileName);
+  const newPath = path.join(profilesDir, safeNewFileName);
+  const oldVersionDir = resolveProfileVersionDir(safeOldFileName);
+  const newVersionDir = resolveProfileVersionDir(safeNewFileName);
+  if (!fs.existsSync(oldPath)) {
+    throw new Error("Profile file not found");
+  }
+  if (fs.existsSync(newPath)) {
+    throw new Error("Target profile file already exists");
+  }
+  if (fs.existsSync(newVersionDir)) {
+    throw new Error("Target profile version history already exists");
+  }
+
+  const migratedVersions = fs.existsSync(oldVersionDir)
+    ? fs.readdirSync(oldVersionDir)
+      .filter((file) => String(file).endsWith(".json"))
+      .map((file) => {
+        const versionFile = String(file);
+        const versionPath = path.join(oldVersionDir, versionFile);
+        try {
+          const version = buildRenamedProfileVersion(
+            versionFile,
+            fs.readFileSync(versionPath, "utf-8").toString(),
+            safeOldFileName,
+            safeNewFileName
+          );
+          return { versionFile, version };
+        } catch {
+          return null;
+        }
+      })
+      .filter((version): version is { versionFile: string; version: ProfileVersion } => Boolean(version))
+    : [];
+
+  let profileRenamed = false;
+  let versionDirRenamed = false;
+  const rewrittenVersionContents = new Map<string, string>();
+
+  try {
+    fs.renameSync(oldPath, newPath);
+    profileRenamed = true;
+    if (!fs.existsSync(oldVersionDir)) return;
+
+    fs.renameSync(oldVersionDir, newVersionDir);
+    versionDirRenamed = true;
+
+    for (const migratedVersion of migratedVersions) {
+      const versionPath = path.join(newVersionDir, migratedVersion.versionFile);
+      rewrittenVersionContents.set(versionPath, fs.readFileSync(versionPath, "utf-8").toString());
+      atomicWriteFile(versionPath, JSON.stringify(migratedVersion.version, null, 2));
+    }
+  } catch (error) {
+    for (const [versionPath, originalContent] of rewrittenVersionContents.entries()) {
+      try {
+        fs.writeFileSync(versionPath, originalContent);
+      } catch {}
+    }
+
+    if (versionDirRenamed) {
+      try {
+        fs.renameSync(newVersionDir, oldVersionDir);
+      } catch {}
+    }
+
+    if (profileRenamed) {
+      try {
+        fs.renameSync(newPath, oldPath);
+      } catch {}
+    }
+
+    throw error;
+  }
 }

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -10,7 +10,24 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { ProfileData, ProfileFallbackModels, ProfileModels } from "./types";
+import {
+  BULK_ASSIGNMENT_MODE,
+  BULK_ASSIGNMENT_TARGET,
+  BulkAssignmentOperation,
+  BulkProfileVersionOperation,
+  PhaseProfileVersionOperation,
+  PROFILE_PHASE_MODEL_FIELD,
+  PROFILE_VERSION_SOURCE,
+  ProfilePhaseModelField,
+  BulkProfilePhaseAssignmentResult,
+  ProfileData,
+  ProfileFallbackModels,
+  ProfileModels,
+  ProfileVersion,
+  ProfileVersionMetadata,
+  ProfileVersionOperation,
+  UpdateProfilePhaseModelResult,
+} from "./types";
 import {
   isManagedSddAgent,
   isFallbackEligibleSddAgent,
@@ -19,11 +36,8 @@ import {
 } from "./utils";
 import { resolvePaths, ensureProfilesDir } from "./config";
 
-export type BulkProfilePhaseAssignmentResult = {
-  profile: ProfileData;
-  modelsAssigned: number;
-  fallbackAssigned: number;
-};
+const PROFILE_VERSION_FORMAT = 1;
+const DEFAULT_PROFILE_VERSION_RETENTION = 30;
 
 function isUnassignedProfileValue(value: unknown): boolean {
   return typeof value !== "string" || value.trim().length === 0;
@@ -144,14 +158,123 @@ export function writeProfileData(profilePath: string, profile: ProfileData): voi
   fs.writeFileSync(profilePath, JSON.stringify(profile, null, 2));
 }
 
+function normalizePrimarySddAgentNames(primarySddAgentNames: string[]): string[] {
+  return Array.from(new Set(primarySddAgentNames))
+    .filter((name) => isPrimarySddAgent(name) && !isSddFallbackAgent(name));
+}
+
+function shouldAssignValue(currentValue: unknown, mode: string): boolean {
+  return mode === BULK_ASSIGNMENT_MODE.OVERWRITE || isUnassignedProfileValue(currentValue);
+}
+
+function safeProfileFileName(profilePathOrFile: string): string {
+  const fileName = path.basename(profilePathOrFile);
+  if (!isSddProfile(fileName) || fileName.includes("..") || fileName.includes("/") || fileName.includes("\\")) {
+    throw new Error("Invalid profile file name");
+  }
+  return fileName;
+}
+
+function resolveProfileVersionDir(profilePathOrFile: string): string {
+  const { profileVersionsDir } = resolvePaths();
+  return path.join(profileVersionsDir, safeProfileFileName(profilePathOrFile));
+}
+
+function sanitizeTimestampForFileName(value: string): string {
+  return value.replace(/[:.]/g, "-");
+}
+
+function parseVersionId(versionId: string): { profileFile: string; versionFile: string } {
+  const parts = versionId.split("/");
+  if (parts.length !== 2) throw new Error("Invalid profile version id");
+  const [profileFile, versionFile] = parts;
+  try {
+    if (profileFile !== safeProfileFileName(profileFile)) throw new Error("Invalid profile version id");
+  } catch {
+    throw new Error("Invalid profile version id");
+  }
+  if (path.basename(versionFile) !== versionFile || !versionFile.endsWith(".json") || versionFile.includes("..")) {
+    throw new Error("Invalid profile version id");
+  }
+  return { profileFile, versionFile };
+}
+
+function resolveProfileVersionPath(versionId: string): string {
+  const { profileFile, versionFile } = parseVersionId(versionId);
+  return path.join(resolveProfileVersionDir(profileFile), versionFile);
+}
+
+function atomicWriteFile(filePath: string, content: string): void {
+  const tmpPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(tmpPath, content);
+  fs.renameSync(tmpPath, filePath);
+}
+
+function buildOperationSummary(operation: BulkAssignmentOperation, modelsAssigned: number, fallbackAssigned: number): string {
+  const action = operation.mode === BULK_ASSIGNMENT_MODE.OVERWRITE ? "Override" : "Set";
+  const target = operation.target === BULK_ASSIGNMENT_TARGET.BOTH
+    ? "all phases and fallbacks"
+    : operation.target === BULK_ASSIGNMENT_TARGET.PRIMARY
+      ? "all primary phases"
+      : "all fallback phases";
+  return `${action} ${target}: ${modelsAssigned} primary, ${fallbackAssigned} fallback`;
+}
+
+function normalizeBulkVersionOperation(
+  operation: BulkAssignmentOperation | BulkProfileVersionOperation,
+  changedPhases?: number
+): BulkProfileVersionOperation {
+  return {
+    ...operation,
+    source: PROFILE_VERSION_SOURCE.BULK,
+    ...(typeof changedPhases === "number" ? { changedPhases } : {}),
+  };
+}
+
+function normalizeProfileVersionOperation(operation: BulkAssignmentOperation | ProfileVersionOperation): ProfileVersionOperation {
+  if ((operation as ProfileVersionOperation).source === PROFILE_VERSION_SOURCE.PHASE) {
+    return operation as PhaseProfileVersionOperation;
+  }
+  return normalizeBulkVersionOperation(operation as BulkAssignmentOperation | BulkProfileVersionOperation);
+}
+
+function normalizeProfileVersion(parsed: any, versionId: string): ProfileVersion {
+  const operation = normalizeProfileVersionOperation(parsed.operation || {});
+  const source = parsed.source === PROFILE_VERSION_SOURCE.PHASE ? PROFILE_VERSION_SOURCE.PHASE : PROFILE_VERSION_SOURCE.BULK;
+  return {
+    ...parsed,
+    source,
+    operation,
+    id: versionId,
+  };
+}
+
+function buildPhaseOperationSummary(agentName: string, field: ProfilePhaseModelField, modelId: string): string {
+  return `Set ${agentName} ${field} model to ${modelId}`;
+}
+
+function readProfilePreviewFromRaw(beforeRaw: string): { models: ProfileModels; fallback: ProfileFallbackModels } {
+  const raw = JSON.parse(beforeRaw);
+  return {
+    models: raw && typeof raw === "object" && !Array.isArray(raw)
+      ? raw.models && typeof raw.models === "object" && !Array.isArray(raw.models)
+        ? Object.fromEntries(
+            Object.entries(raw.models).filter(([name, value]: any) => isPrimarySddAgent(name) && typeof value === "string")
+          )
+        : extractSddAgentModels(raw)
+      : {},
+    fallback: extractSddFallbackModels(raw),
+  };
+}
+
 /**
- * Assigns a model to every unassigned SDD phase in a profile without overwriting
- * existing non-empty primary or fallback assignments.
+ * Applies a bulk profile assignment for the selected target/mode without mutating input.
  */
-export function assignModelToUnassignedProfilePhases(
+export function applyBulkProfilePhaseAssignment(
   profile: ProfileData,
   primarySddAgentNames: string[],
-  modelId: string
+  modelId: string,
+  operation: BulkAssignmentOperation
 ): BulkProfilePhaseAssignmentResult {
   const trimmedModelId = modelId?.trim();
   if (!trimmedModelId) {
@@ -160,21 +283,29 @@ export function assignModelToUnassignedProfilePhases(
 
   const nextModels: ProfileModels = { ...(profile?.models || {}) };
   const nextFallback: ProfileFallbackModels = { ...(profile?.fallback || {}) };
+  const primaryAgentNames = normalizePrimarySddAgentNames(primarySddAgentNames);
   let modelsAssigned = 0;
   let fallbackAssigned = 0;
+  let changed = false;
 
-  const primaryAgentNames = Array.from(new Set(primarySddAgentNames))
-    .filter((name) => isPrimarySddAgent(name) && !isSddFallbackAgent(name));
+  const shouldAssignPrimary = operation.target === BULK_ASSIGNMENT_TARGET.PRIMARY || operation.target === BULK_ASSIGNMENT_TARGET.BOTH;
+  const shouldAssignFallback = operation.target === BULK_ASSIGNMENT_TARGET.FALLBACK || operation.target === BULK_ASSIGNMENT_TARGET.BOTH;
 
   for (const agentName of primaryAgentNames) {
-    if (isUnassignedProfileValue(nextModels[agentName])) {
-      nextModels[agentName] = trimmedModelId;
-      modelsAssigned += 1;
+    if (shouldAssignPrimary && shouldAssignValue(nextModels[agentName], operation.mode)) {
+      if (nextModels[agentName] !== trimmedModelId) {
+        nextModels[agentName] = trimmedModelId;
+        modelsAssigned += 1;
+        changed = true;
+      }
     }
 
-    if (isFallbackEligibleSddAgent(agentName) && isUnassignedProfileValue(nextFallback[agentName])) {
-      nextFallback[agentName] = trimmedModelId;
-      fallbackAssigned += 1;
+    if (shouldAssignFallback && isFallbackEligibleSddAgent(agentName) && shouldAssignValue(nextFallback[agentName], operation.mode)) {
+      if (nextFallback[agentName] !== trimmedModelId) {
+        nextFallback[agentName] = trimmedModelId;
+        fallbackAssigned += 1;
+        changed = true;
+      }
     }
   }
 
@@ -186,7 +317,167 @@ export function assignModelToUnassignedProfilePhases(
     },
     modelsAssigned,
     fallbackAssigned,
+    changed,
   };
+}
+
+/**
+ * Assigns a model to every unassigned SDD phase in a profile without overwriting
+ * existing non-empty primary or fallback assignments.
+ */
+export function assignModelToUnassignedProfilePhases(
+  profile: ProfileData,
+  primarySddAgentNames: string[],
+  modelId: string
+): BulkProfilePhaseAssignmentResult {
+  return applyBulkProfilePhaseAssignment(profile, primarySddAgentNames, modelId, {
+    target: BULK_ASSIGNMENT_TARGET.BOTH,
+    mode: BULK_ASSIGNMENT_MODE.FILL_ONLY,
+  });
+}
+
+function pruneProfileVersions(profileFile: string, retention: number): void {
+  const versionDir = resolveProfileVersionDir(profileFile);
+  if (!fs.existsSync(versionDir)) return;
+  const files = fs.readdirSync(versionDir).filter((file) => String(file).endsWith(".json")).sort().reverse();
+  for (const staleFile of files.slice(retention)) {
+    fs.unlinkSync(path.join(versionDir, staleFile));
+  }
+}
+
+export function createProfileVersion(
+  profilePath: string,
+  operation: BulkAssignmentOperation | ProfileVersionOperation,
+  operationSummary: string,
+  retention = DEFAULT_PROFILE_VERSION_RETENTION
+): ProfileVersion {
+  const profileFile = safeProfileFileName(profilePath);
+  const versionDir = resolveProfileVersionDir(profileFile);
+  if (!fs.existsSync(versionDir)) fs.mkdirSync(versionDir, { recursive: true });
+
+  const beforeRaw = fs.readFileSync(profilePath, "utf-8").toString();
+  const createdAt = new Date().toISOString();
+  const versionFile = `${sanitizeTimestampForFileName(createdAt)}-${Math.random().toString(36).slice(2, 8)}.json`;
+  const id = `${profileFile}/${versionFile}`;
+  const versionOperation = normalizeProfileVersionOperation(operation);
+  const version: ProfileVersion = {
+    version: PROFILE_VERSION_FORMAT,
+    id,
+    profileFile,
+    createdAt,
+    source: versionOperation.source,
+    operation: versionOperation,
+    operationSummary,
+    beforeRaw,
+    preview: readProfilePreviewFromRaw(beforeRaw),
+  };
+
+  const versionPath = path.join(versionDir, versionFile);
+  atomicWriteFile(versionPath, JSON.stringify(version, null, 2));
+  pruneProfileVersions(profileFile, retention);
+  return version;
+}
+
+export function readProfileVersion(versionId: string): ProfileVersion {
+  const versionPath = resolveProfileVersionPath(versionId);
+  if (!fs.existsSync(versionPath)) throw new Error("Profile version not found");
+  const parsed = JSON.parse(fs.readFileSync(versionPath, "utf-8").toString());
+  if (parsed?.version !== PROFILE_VERSION_FORMAT || parsed?.id !== versionId || parsed?.profileFile !== parseVersionId(versionId).profileFile) {
+    throw new Error("Invalid profile version data");
+  }
+  return normalizeProfileVersion(parsed, versionId);
+}
+
+export function listProfileVersions(profilePathOrFile: string): ProfileVersionMetadata[] {
+  const profileFile = safeProfileFileName(profilePathOrFile);
+  const versionDir = resolveProfileVersionDir(profileFile);
+  if (!fs.existsSync(versionDir)) return [];
+
+  return fs.readdirSync(versionDir)
+    .filter((file) => String(file).endsWith(".json"))
+    .map((file) => readProfileVersion(`${profileFile}/${file}`))
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+    .map(({ beforeRaw, ...metadata }) => metadata);
+}
+
+export function restoreProfileVersion(profilePathOrFile: string, versionId: string): ProfileVersion {
+  const profileFile = safeProfileFileName(profilePathOrFile);
+  const version = readProfileVersion(versionId);
+  if (version.profileFile !== profileFile) {
+    throw new Error("Profile version does not match selected profile");
+  }
+  JSON.parse(version.beforeRaw);
+  const { profilesDir } = resolvePaths();
+  fs.writeFileSync(path.join(profilesDir, profileFile), version.beforeRaw);
+  return version;
+}
+
+export function updateProfileWithBulkPhaseAssignment(
+  profilePath: string,
+  primarySddAgentNames: string[],
+  modelId: string,
+  operation: BulkAssignmentOperation
+): { assignment: BulkProfilePhaseAssignmentResult; version?: ProfileVersion } {
+  const profileData = readProfileData(profilePath);
+  const assignment = applyBulkProfilePhaseAssignment(profileData, primarySddAgentNames, modelId, operation);
+  if (!assignment.changed) return { assignment };
+
+  const version = createProfileVersion(
+    profilePath,
+    normalizeBulkVersionOperation(operation, assignment.modelsAssigned + assignment.fallbackAssigned),
+    buildOperationSummary(operation, assignment.modelsAssigned, assignment.fallbackAssigned)
+  );
+  writeProfileData(profilePath, assignment.profile);
+  return { assignment, version };
+}
+
+export function updateProfilePhaseModel(
+  profilePath: string,
+  agentName: string,
+  field: ProfilePhaseModelField,
+  modelId: string
+): UpdateProfilePhaseModelResult {
+  const trimmedModelId = modelId?.trim();
+  if (!trimmedModelId) {
+    throw new Error("modelId must be a non-empty string");
+  }
+  if (!isPrimarySddAgent(agentName) || isSddFallbackAgent(agentName)) {
+    throw new Error("agentName must be a primary SDD agent");
+  }
+  if (field === PROFILE_PHASE_MODEL_FIELD.FALLBACK && !isFallbackEligibleSddAgent(agentName)) {
+    throw new Error("agentName is not eligible for fallback models");
+  }
+
+  const profileData = readProfileData(profilePath);
+  const currentValue = field === PROFILE_PHASE_MODEL_FIELD.FALLBACK
+    ? profileData.fallback?.[agentName]
+    : profileData.models?.[agentName];
+  if (currentValue === trimmedModelId) {
+    return { profile: profileData, changed: false };
+  }
+
+  const nextProfile: ProfileData = {
+    ...profileData,
+    models: { ...(profileData.models || {}) },
+    fallback: { ...(profileData.fallback || {}) },
+  };
+
+  if (field === PROFILE_PHASE_MODEL_FIELD.FALLBACK) {
+    nextProfile.fallback = { ...(nextProfile.fallback || {}), [agentName]: trimmedModelId };
+  } else {
+    nextProfile.models = { ...(nextProfile.models || {}), [agentName]: trimmedModelId };
+  }
+
+  const operation: PhaseProfileVersionOperation = {
+    source: PROFILE_VERSION_SOURCE.PHASE,
+    phase: agentName,
+    field,
+    modelId: trimmedModelId,
+    changedPhases: 1,
+  };
+  const version = createProfileVersion(profilePath, operation, buildPhaseOperationSummary(agentName, field, trimmedModelId));
+  writeProfileData(profilePath, nextProfile);
+  return { profile: nextProfile, changed: true, version };
 }
 
 /**

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -37,7 +37,7 @@ import {
 import { resolvePaths, ensureProfilesDir } from "./config";
 
 const PROFILE_VERSION_FORMAT = 1;
-const DEFAULT_PROFILE_VERSION_RETENTION = 30;
+const DEFAULT_PROFILE_VERSION_RETENTION = 60;
 
 function isUnassignedProfileValue(value: unknown): boolean {
   return typeof value !== "string" || value.trim().length === 0;

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -19,6 +19,16 @@ import {
 } from "./utils";
 import { resolvePaths, ensureProfilesDir } from "./config";
 
+export type BulkProfilePhaseAssignmentResult = {
+  profile: ProfileData;
+  modelsAssigned: number;
+  fallbackAssigned: number;
+};
+
+function isUnassignedProfileValue(value: unknown): boolean {
+  return typeof value !== "string" || value.trim().length === 0;
+}
+
 /**
  * Checks if a file name represents a valid SDD profile
  *
@@ -119,9 +129,63 @@ export function readProfileFallbackModels(profilePath: string): ProfileFallbackM
  * Reads full profile data from file (models + fallback)
  */
 export function readProfileData(profilePath: string): ProfileData {
+  const raw = JSON.parse(fs.readFileSync(profilePath, "utf-8"));
   return {
+    ...(raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {}),
     models: readProfileModels(profilePath),
     fallback: readProfileFallbackModels(profilePath),
+  };
+}
+
+/**
+ * Persists full profile data while preserving the existing profile payload shape.
+ */
+export function writeProfileData(profilePath: string, profile: ProfileData): void {
+  fs.writeFileSync(profilePath, JSON.stringify(profile, null, 2));
+}
+
+/**
+ * Assigns a model to every unassigned SDD phase in a profile without overwriting
+ * existing non-empty primary or fallback assignments.
+ */
+export function assignModelToUnassignedProfilePhases(
+  profile: ProfileData,
+  primarySddAgentNames: string[],
+  modelId: string
+): BulkProfilePhaseAssignmentResult {
+  const trimmedModelId = modelId?.trim();
+  if (!trimmedModelId) {
+    throw new Error("modelId must be a non-empty string");
+  }
+
+  const nextModels: ProfileModels = { ...(profile?.models || {}) };
+  const nextFallback: ProfileFallbackModels = { ...(profile?.fallback || {}) };
+  let modelsAssigned = 0;
+  let fallbackAssigned = 0;
+
+  const primaryAgentNames = Array.from(new Set(primarySddAgentNames))
+    .filter((name) => isPrimarySddAgent(name) && !isSddFallbackAgent(name));
+
+  for (const agentName of primaryAgentNames) {
+    if (isUnassignedProfileValue(nextModels[agentName])) {
+      nextModels[agentName] = trimmedModelId;
+      modelsAssigned += 1;
+    }
+
+    if (isFallbackEligibleSddAgent(agentName) && isUnassignedProfileValue(nextFallback[agentName])) {
+      nextFallback[agentName] = trimmedModelId;
+      fallbackAssigned += 1;
+    }
+  }
+
+  return {
+    profile: {
+      ...(profile || {}),
+      models: nextModels,
+      fallback: nextFallback,
+    },
+    modelsAssigned,
+    fallbackAssigned,
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,87 @@ export type ProfileData = {
   fallback?: ProfileFallbackModels;
 };
 
+export const BULK_ASSIGNMENT_TARGET = {
+  PRIMARY: "primary",
+  FALLBACK: "fallback",
+  BOTH: "both",
+} as const;
+
+export type BulkAssignmentTarget = (typeof BULK_ASSIGNMENT_TARGET)[keyof typeof BULK_ASSIGNMENT_TARGET];
+
+export const BULK_ASSIGNMENT_MODE = {
+  FILL_ONLY: "fill-only",
+  OVERWRITE: "overwrite",
+} as const;
+
+export type BulkAssignmentMode = (typeof BULK_ASSIGNMENT_MODE)[keyof typeof BULK_ASSIGNMENT_MODE];
+
+export type BulkAssignmentOperation = {
+  target: BulkAssignmentTarget;
+  mode: BulkAssignmentMode;
+};
+
+export const PROFILE_VERSION_SOURCE = {
+  BULK: "bulk",
+  PHASE: "phase",
+} as const;
+
+export type ProfileVersionSource = (typeof PROFILE_VERSION_SOURCE)[keyof typeof PROFILE_VERSION_SOURCE];
+
+export const PROFILE_PHASE_MODEL_FIELD = {
+  PRIMARY: "primary",
+  FALLBACK: "fallback",
+} as const;
+
+export type ProfilePhaseModelField = (typeof PROFILE_PHASE_MODEL_FIELD)[keyof typeof PROFILE_PHASE_MODEL_FIELD];
+
+export type BulkProfileVersionOperation = BulkAssignmentOperation & {
+  source: typeof PROFILE_VERSION_SOURCE.BULK;
+  changedPhases?: number;
+};
+
+export type PhaseProfileVersionOperation = {
+  source: typeof PROFILE_VERSION_SOURCE.PHASE;
+  phase: string;
+  field: ProfilePhaseModelField;
+  modelId: string;
+  changedPhases: 1;
+};
+
+export type ProfileVersionOperation = BulkProfileVersionOperation | PhaseProfileVersionOperation;
+
+export type BulkProfilePhaseAssignmentResult = {
+  profile: ProfileData;
+  modelsAssigned: number;
+  fallbackAssigned: number;
+  changed: boolean;
+};
+
+export type ProfileVersionPreview = {
+  models: ProfileModels;
+  fallback: ProfileFallbackModels;
+};
+
+export type ProfileVersion = {
+  version: 1;
+  id: string;
+  profileFile: string;
+  createdAt: string;
+  source: ProfileVersionSource;
+  operation: ProfileVersionOperation;
+  operationSummary: string;
+  beforeRaw: string;
+  preview: ProfileVersionPreview;
+};
+
+export type UpdateProfilePhaseModelResult = {
+  profile: ProfileData;
+  changed: boolean;
+  version?: ProfileVersion;
+};
+
+export type ProfileVersionMetadata = Omit<ProfileVersion, "beforeRaw">;
+
 /**
  * Represents the persistent state of profiles
  */


### PR DESCRIPTION
## Linked Issue

Closes #14

## PR Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Adds bulk profile actions for primary phases, fallback phases, and combined primary/fallback assignment with explicit override flows.
- Adds profile version history with timestamped snapshots, preview, restore, phase-change versioning, retention, and hardened file safety.
- Documents the new profile workflows and adds PR CI for test/build validation.

## Changes

| File | Change |
|------|--------|
| `src/dialogs.tsx` | Adds bulk actions menu, profile versions UI, restore flow, safer create/rename input handling. |
| `src/profiles.ts` | Adds bulk assignment helpers, profile version persistence, restore/rename/delete safety, validation, retention, and canonical writes. |
| `src/types.ts` | Adds bulk assignment and profile version types. |
| `src/config.ts` | Adds profile versions directory resolution. |
| `src/*.test.ts` | Adds coverage for bulk assignment, version history, restore, rename/delete safety, corrupt snapshots, CI-relevant behavior. |
| `README.md` | Documents bulk actions, profile versions, storage, restore, and text screenshots. |
| `.github/workflows/ci.yml` | Adds CI workflow for PR/push validation with `npm ci`, `npm test`, and `npm run build`. |
| `.gitignore` | Ignores local `.atl` artifacts. |

## Test Plan

- [x] `npm test` — 110 tests passing after Judgment Day hardening fixes
- [x] Manually tested `/sdd-model` locally by loading the plugin from the local checkout path
- [x] Verified bulk actions and profile versions work in a real local OpenCode config
- [x] Added GitHub Actions CI to run `npm ci`, `npm test`, and `npm run build`
- [x] Ran adversarial Judgment Day review and fixed confirmed safety/data issues

## Contributor Checklist

- [x] I linked an approved issue
- [x] This PR should use exactly one `type:*` label: `type:feature`
- [x] I used conventional commit format
- [x] I did not add `Co-Authored-By` trailers
- [x] I updated documentation for user-visible behavior changes