### PR TITLE
fix: handle EPERM on fsync for Windows compatibility

### DIFF
--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -316,7 +316,7 @@ function atomicWriteFile(filePath: string, content: string): void {
     fs.writeFileSync(tmpPath, content);
 
     tempFd = fs.openSync(tmpPath, "r+");
-    fs.fsyncSync(tempFd);
+    try { fs.fsyncSync(tempFd); } catch (e: any) { if (e?.code !== "EPERM") throw e; }
     fs.closeSync(tempFd);
     tempFd = undefined;
 
@@ -324,7 +324,7 @@ function atomicWriteFile(filePath: string, content: string): void {
     renameCompleted = true;
 
     dirFd = fs.openSync(path.dirname(filePath), "r");
-    fs.fsyncSync(dirFd);
+    try { fs.fsyncSync(dirFd); } catch (e: any) { if (e?.code !== "EPERM") throw e; }
   } finally {
     if (typeof tempFd === "number") {
       fs.closeSync(tempFd);


### PR DESCRIPTION
## Summary
- Wraps `fs.fsyncSync()` calls in `atomicWriteFile()` with try/catch that silently ignores `EPERM` errors (re-throws other errors)
- Fixes `"Failed to update agent: EPERM: operation not permitted, fsync"` when editing individual SDD agent models in profile files on Windows

## Why
On Windows, `fs.fsyncSync()` on file descriptors opened with `"r+"` mode (or on directory descriptors opened with `"r"`) can throw `EPERM` because the Win32 `FlushFileBuffers` API requires `GENERIC_WRITE` access, which Node.js does not always provide when using read modes. This is a known Node.js-on-Windows limitation.

## What changed
In `src/profiles.ts`, the `atomicWriteFile()` function:
- **Line 319**: `fs.fsyncSync(tempFd)` -> wrapped in try/catch
- **Line 327**: `fs.fsyncSync(dirFd)` -> wrapped in try/catch

Both catch blocks only re-throw if `error.code !== "EPERM"`, preserving error visibility for genuine failures while tolerating Windows fsync quirks.

## Impact
- **non-breaking**: fsync is a durability optimization, not a correctness requirement
- Config/profile data is already written to disk by `writeFileSync` before fsync is called
- Only affects Windows - Linux/macOS behavior is unchanged (EPERM is not thrown there)
- The atomic rename (`tmpPath` -> `filePath`) still completes successfully even if fsync is skipped

## Tested
- [x] Reproduced the EPERM error on Windows 11
- [x] Fix applied - agent model edits in profile files now succeed
- [x] Other errors (ENOENT, EACCES, etc.) still propagate correctly