### PR TITLE
fix(profiles): map legacy orchestrator profile to gentle-orchestrator

### DIFF
--- a/src/profiles.test.ts
+++ b/src/profiles.test.ts
@@ -414,6 +414,26 @@ describe('profiles logic', () => {
       expect(nextConfig.agent['sdd-init'].model).toBe('claude-3');
       expect(nextConfig.agent['sdd-init-fallback'].model).toBe('gpt-3.5');
     });
+
+    it('maps legacy sdd-orchestrator profile models to gentle-orchestrator at runtime', () => {
+      const config = {
+        agent: {
+          'gentle-orchestrator': { model: 'old/model', prompt: '{file:orchestrator.md}' }
+        }
+      };
+      const profile = {
+        models: { 'sdd-orchestrator': 'new/model' },
+        fallback: {}
+      };
+
+      const nextConfig = applyProfileDataToConfig(config, profile);
+
+      expect(nextConfig.agent['gentle-orchestrator']).toEqual({
+        model: 'new/model',
+        prompt: '{file:orchestrator.md}'
+      });
+      expect(nextConfig.agent['sdd-orchestrator']).toBeUndefined();
+    });
   });
 
   describe('assignModelToUnassignedProfilePhases', () => {
@@ -1439,6 +1459,44 @@ describe('profiles logic', () => {
   });
 
   describe('activateProfileFile', () => {
+    it('activates legacy sdd-orchestrator profile models on gentle-orchestrator', async () => {
+      const updatedConfigs: any[] = [];
+      vi.mocked(fs.existsSync).mockImplementation((filePath: any) => String(filePath) === '/mock/config/opencode.json');
+      vi.mocked(fs.readFileSync).mockImplementation((filePath: any) => {
+        if (String(filePath) === '/mock/profiles/team.json') {
+          return JSON.stringify({ models: { 'sdd-orchestrator': 'new/model' } });
+        }
+
+        return JSON.stringify({
+          agent: {
+            'gentle-orchestrator': { model: 'old/model', prompt: '{file:orchestrator.md}' }
+          }
+        });
+      });
+
+      const api = {
+        ui: { toast: vi.fn() },
+        client: {
+          global: {
+            config: {
+              get: vi.fn(),
+              update: vi.fn(({ config }) => {
+                updatedConfigs.push(config);
+                return { data: config };
+              }),
+            },
+          },
+        },
+      } as any;
+
+      const result = await activateProfileFile(api, '/mock/profiles/team.json', 'team');
+
+      expect(api.client.global.config.update).toHaveBeenCalledTimes(1);
+      expect(updatedConfigs[0].agent['gentle-orchestrator'].model).toBe('new/model');
+      expect(updatedConfigs[0].agent['sdd-orchestrator']).toBeUndefined();
+      expect(result).toEqual(updatedConfigs[0]);
+    });
+
     it('returns null and shows toast when on-disk global config JSON is invalid', async () => {
       vi.mocked(fs.existsSync).mockImplementation((filePath: any) => String(filePath) === '/mock/config/opencode.json');
       vi.mocked(fs.readFileSync).mockImplementation((filePath: any) => {

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -40,9 +40,15 @@ import { resolvePaths, ensureProfilesDir } from "./config";
 const PROFILE_VERSION_FORMAT = 1;
 const DEFAULT_PROFILE_VERSION_RETENTION = 60;
 const PROFILE_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._ -]*$/;
+const LEGACY_ORCHESTRATOR_AGENT = "sdd-orchestrator";
+const RUNTIME_ORCHESTRATOR_AGENT = "gentle-orchestrator";
 
 function isUnassignedProfileValue(value: unknown): boolean {
   return typeof value !== "string" || value.trim().length === 0;
+}
+
+function resolveRuntimeProfileAgentName(agentName: string): string {
+  return agentName === LEGACY_ORCHESTRATOR_AGENT ? RUNTIME_ORCHESTRATOR_AGENT : agentName;
 }
 
 /**
@@ -955,8 +961,9 @@ function applyProfileModelsToConfig(currentConfig: any, profileModels: ProfileMo
   if (!nextConfig.agent) nextConfig.agent = {};
 
   for (const [agentName, modelId] of Object.entries(profileModels)) {
-    nextConfig.agent[agentName] = {
-      ...(nextConfig.agent[agentName] || {}),
+    const runtimeAgentName = resolveRuntimeProfileAgentName(agentName);
+    nextConfig.agent[runtimeAgentName] = {
+      ...(nextConfig.agent[runtimeAgentName] || {}),
       model: modelId,
     };
   }


### PR DESCRIPTION
Closes #19

## Summary
- map legacy profile key `sdd-orchestrator` to the runtime `gentle-orchestrator` agent during profile activation
- preserve existing orchestrator fields while replacing only the configured model
- add regression coverage to ensure activation does not create `agent.sdd-orchestrator`

## Changes
| File | Change |
|------|--------|
| `src/profiles.ts` | map the legacy profile key to the runtime orchestrator before applying models |
| `src/profiles.test.ts` | add focused regression tests for config application and activation |

## Test Notes
- [x] Focused tests pass: `npm test -- src/profiles.test.ts`
- [x] Local runtime behavior was validated against the installed plugin cache before restore
- [x] Diff stays narrowly scoped to the reported bug
