### PR TITLE
feat: add structured logger and wire into silent catch blocks

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,9 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import { execFileSync } from "node:child_process";
+import { createLogger } from "./logger";
+
+const log = createLogger("config");
 
 /**
  * Collection of core plugin paths
@@ -51,7 +54,9 @@ export function ensureProfilesDir(): void {
   if (!fs.existsSync(profilesDir)) {
     try {
       fs.mkdirSync(profilesDir, { recursive: true });
-    } catch (e) {}
+    } catch (e) {
+      log.warn("ensureProfilesDir: failed to create profiles directory", e);
+    }
   }
 }
 

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createLogger } from './logger';
+
+describe('logger', () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  const originalDebug = process.env.SDD_PLUGIN_DEBUG;
+
+  beforeEach(() => {
+    stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    delete process.env.SDD_PLUGIN_DEBUG;
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+    if (originalDebug === undefined) {
+      delete process.env.SDD_PLUGIN_DEBUG;
+    } else {
+      process.env.SDD_PLUGIN_DEBUG = originalDebug;
+    }
+  });
+
+  describe('createLogger', () => {
+    it('returns an object with info, warn, error, debug methods', () => {
+      const log = createLogger('config');
+      expect(typeof log.info).toBe('function');
+      expect(typeof log.warn).toBe('function');
+      expect(typeof log.error).toBe('function');
+      expect(typeof log.debug).toBe('function');
+    });
+  });
+
+  describe('output format and routing', () => {
+    it('prefixes info with [sdd-plugin][<namespace>] and writes to stderr', () => {
+      const log = createLogger('profiles');
+      log.info('something happened');
+      expect(stderrSpy).toHaveBeenCalledTimes(1);
+      expect(stderrSpy).toHaveBeenCalledWith(
+        '[sdd-plugin][profiles] something happened'
+      );
+    });
+
+    it('prefixes warn with [sdd-plugin][<namespace>] and writes to stderr', () => {
+      const log = createLogger('config');
+      log.warn('mkdir failed');
+      expect(stderrSpy).toHaveBeenCalledWith(
+        '[sdd-plugin][config] mkdir failed'
+      );
+    });
+
+    it('prefixes error with [sdd-plugin][<namespace>] and writes to stderr', () => {
+      const log = createLogger('memories');
+      log.error('engram unreachable');
+      expect(stderrSpy).toHaveBeenCalledWith(
+        '[sdd-plugin][memories] engram unreachable'
+      );
+    });
+
+    it('forwards extra args after the message', () => {
+      const log = createLogger('profiles');
+      const err = new Error('boom');
+      log.warn('readProfile failed', err);
+      expect(stderrSpy).toHaveBeenCalledWith(
+        '[sdd-plugin][profiles] readProfile failed',
+        err
+      );
+    });
+  });
+
+  describe('debug gating via SDD_PLUGIN_DEBUG', () => {
+    it('does NOT emit debug by default', () => {
+      const log = createLogger('profiles');
+      log.debug('verbose detail');
+      expect(stderrSpy).not.toHaveBeenCalled();
+    });
+
+    it('emits debug when SDD_PLUGIN_DEBUG=1', () => {
+      process.env.SDD_PLUGIN_DEBUG = '1';
+      const log = createLogger('profiles');
+      log.debug('verbose detail');
+      expect(stderrSpy).toHaveBeenCalledWith(
+        '[sdd-plugin][profiles] verbose detail'
+      );
+    });
+
+    it('does NOT emit debug when SDD_PLUGIN_DEBUG is set to other values', () => {
+      process.env.SDD_PLUGIN_DEBUG = 'true';
+      const log = createLogger('profiles');
+      log.debug('verbose detail');
+      expect(stderrSpy).not.toHaveBeenCalled();
+
+      process.env.SDD_PLUGIN_DEBUG = '0';
+      log.debug('still off');
+      expect(stderrSpy).not.toHaveBeenCalled();
+    });
+
+    it('reads env dynamically per call (toggle at runtime)', () => {
+      const log = createLogger('profiles');
+
+      log.debug('off');
+      expect(stderrSpy).not.toHaveBeenCalled();
+
+      process.env.SDD_PLUGIN_DEBUG = '1';
+      log.debug('on');
+      expect(stderrSpy).toHaveBeenCalledTimes(1);
+
+      delete process.env.SDD_PLUGIN_DEBUG;
+      log.debug('off again');
+      expect(stderrSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('namespace isolation', () => {
+    it('uses the namespace from createLogger, not a global one', () => {
+      const a = createLogger('config');
+      const b = createLogger('profiles');
+      a.warn('A');
+      b.warn('B');
+      expect(stderrSpy).toHaveBeenNthCalledWith(1, '[sdd-plugin][config] A');
+      expect(stderrSpy).toHaveBeenNthCalledWith(2, '[sdd-plugin][profiles] B');
+    });
+  });
+});

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -6,6 +6,7 @@ describe('logger', () => {
   const originalDebug = process.env.SDD_PLUGIN_DEBUG;
 
   beforeEach(() => {
+    vi.resetAllMocks();
     stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     delete process.env.SDD_PLUGIN_DEBUG;
   });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,47 @@
+/**
+ * Minimal structured logger for the sdd-engram-plugin.
+ *
+ * - Four levels: info, warn, error, debug.
+ * - All output goes to stderr via console.error to avoid polluting the TUI stdout.
+ * - debug is silenced by default and activated by setting SDD_PLUGIN_DEBUG=1.
+ * - Each line is prefixed with [sdd-plugin][<namespace>] for grep-ability.
+ */
+
+export interface Logger {
+  info(message: string, ...args: unknown[]): void;
+  warn(message: string, ...args: unknown[]): void;
+  error(message: string, ...args: unknown[]): void;
+  debug(message: string, ...args: unknown[]): void;
+}
+
+function isDebugEnabled(): boolean {
+  return process.env.SDD_PLUGIN_DEBUG === "1";
+}
+
+export function createLogger(namespace: string): Logger {
+  const prefix = `[sdd-plugin][${namespace}]`;
+
+  const emit = (message: string, args: unknown[]): void => {
+    if (args.length > 0) {
+      console.error(`${prefix} ${message}`, ...args);
+    } else {
+      console.error(`${prefix} ${message}`);
+    }
+  };
+
+  return {
+    info(message, ...args) {
+      emit(message, args);
+    },
+    warn(message, ...args) {
+      emit(message, args);
+    },
+    error(message, ...args) {
+      emit(message, args);
+    },
+    debug(message, ...args) {
+      if (!isDebugEnabled()) return;
+      emit(message, args);
+    },
+  };
+}

--- a/src/memories.test.ts
+++ b/src/memories.test.ts
@@ -12,7 +12,7 @@ describe('memories logic', () => {
   const mockApi = { state: { path: { directory: '/path/to/repo' } } };
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     mockFetch.mockReset();
   });
 
@@ -89,11 +89,42 @@ describe('memories logic', () => {
       expect(result.length).toBe(1);
     });
 
+    it('should deduplicate memories when matching IDs use different primitive types', async () => {
+      vi.mocked(resolveProjectCandidates).mockReturnValue(['repo1', 'repo2']);
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [{ id: 1, title: 'same' }]
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [{ id: '1', title: 'same duplicate' }]
+        });
+
+      const result = await listProjectMemories(mockApi);
+      expect(result.length).toBe(1);
+      expect(result[0].id).toBe(1);
+    });
+
     it('should handle API failures gracefully', async () => {
       vi.mocked(resolveProjectCandidates).mockReturnValue(['repo']);
       mockFetch.mockRejectedValue(new Error('network error'));
 
       expect(await listProjectMemories(mockApi)).toEqual([]);
+    });
+
+    it('should log candidate fetch failures before returning empty list', async () => {
+      vi.mocked(resolveProjectCandidates).mockReturnValue(['repo']);
+      const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockFetch.mockRejectedValue(new Error('network error'));
+
+      expect(await listProjectMemories(mockApi)).toEqual([]);
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[sdd-plugin][memories] listProjectMemories: failed to fetch recent observations for candidate 'repo'"),
+        expect.any(Error)
+      );
+      stderrSpy.mockRestore();
     });
   });
 

--- a/src/memories.test.ts
+++ b/src/memories.test.ts
@@ -89,24 +89,6 @@ describe('memories logic', () => {
       expect(result.length).toBe(1);
     });
 
-    it('should deduplicate memories when matching IDs use different primitive types', async () => {
-      vi.mocked(resolveProjectCandidates).mockReturnValue(['repo1', 'repo2']);
-
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => [{ id: 1, title: 'same' }]
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => [{ id: '1', title: 'same duplicate' }]
-        });
-
-      const result = await listProjectMemories(mockApi);
-      expect(result.length).toBe(1);
-      expect(result[0].id).toBe(1);
-    });
-
     it('should handle API failures gracefully', async () => {
       vi.mocked(resolveProjectCandidates).mockReturnValue(['repo']);
       mockFetch.mockRejectedValue(new Error('network error'));

--- a/src/memories.ts
+++ b/src/memories.ts
@@ -15,13 +15,7 @@ import type { EngramObservation } from "./types";
 
 const log = createLogger("memories");
 
-const DEFAULT_ENGRAM_PORT = 7437;
-const parsedEngramPort = Number.parseInt(process.env.ENGRAM_PORT ?? String(DEFAULT_ENGRAM_PORT), 10);
-const ENGRAM_PORT = Number.isInteger(parsedEngramPort)
-  && parsedEngramPort > 0
-  && parsedEngramPort <= 65535
-  ? parsedEngramPort
-  : DEFAULT_ENGRAM_PORT;
+const ENGRAM_PORT = parseInt(process.env.ENGRAM_PORT ?? "7437");
 const ENGRAM_URL = `http://127.0.0.1:${ENGRAM_PORT}`;
 
 /**
@@ -85,9 +79,8 @@ export async function listProjectMemories(api: any): Promise<EngramObservation[]
     const uniqueMemories = [];
 
     for (const memory of flatData) {
-      const memoryId = Number(memory?.id);
-      if (memory?.id && !seenIds.has(memoryId)) {
-        seenIds.add(memoryId);
+      if (memory?.id && !seenIds.has(memory.id)) {
+        seenIds.add(memory.id);
         uniqueMemories.push(normalizeMemory(memory, projectName));
       }
     }

--- a/src/memories.ts
+++ b/src/memories.ts
@@ -10,7 +10,10 @@
 
 import * as path from "node:path";
 import { resolveProjectCandidates, resolveProjectName } from "./config";
+import { createLogger } from "./logger";
 import type { EngramObservation } from "./types";
+
+const log = createLogger("memories");
 
 const ENGRAM_PORT = parseInt(process.env.ENGRAM_PORT ?? "7437");
 const ENGRAM_URL = `http://127.0.0.1:${ENGRAM_PORT}`;
@@ -88,7 +91,7 @@ export async function listProjectMemories(api: any): Promise<EngramObservation[]
       return dateB.localeCompare(dateA);
     });
   } catch (error) {
-    console.error("Failed to list project memories via Engram API:", error);
+    log.error("listProjectMemories: failed to list project memories via Engram API", error);
     return [];
   }
 }
@@ -115,7 +118,7 @@ export async function deleteProjectMemory(memoryId: number): Promise<void> {
       throw new Error(`Engram API delete returned ${res.status}: ${res.statusText}`);
     }
   } catch (error) {
-    console.error(`Failed to delete memory ${safeId} via Engram API:`, error);
+    log.error(`deleteProjectMemory: failed to delete memory ${safeId} via Engram API`, error);
     throw error;
   }
 }

--- a/src/memories.ts
+++ b/src/memories.ts
@@ -15,7 +15,13 @@ import type { EngramObservation } from "./types";
 
 const log = createLogger("memories");
 
-const ENGRAM_PORT = parseInt(process.env.ENGRAM_PORT ?? "7437");
+const DEFAULT_ENGRAM_PORT = 7437;
+const parsedEngramPort = Number.parseInt(process.env.ENGRAM_PORT ?? String(DEFAULT_ENGRAM_PORT), 10);
+const ENGRAM_PORT = Number.isInteger(parsedEngramPort)
+  && parsedEngramPort > 0
+  && parsedEngramPort <= 65535
+  ? parsedEngramPort
+  : DEFAULT_ENGRAM_PORT;
 const ENGRAM_URL = `http://127.0.0.1:${ENGRAM_PORT}`;
 
 /**
@@ -64,7 +70,8 @@ export async function listProjectMemories(api: any): Promise<EngramObservation[]
             signal: AbortSignal.timeout(3000),
           });
           return res.ok ? await res.json() : [];
-        } catch {
+        } catch (error) {
+          log.warn(`listProjectMemories: failed to fetch recent observations for candidate '${project}'`, error);
           return [];
         }
       })
@@ -78,8 +85,9 @@ export async function listProjectMemories(api: any): Promise<EngramObservation[]
     const uniqueMemories = [];
 
     for (const memory of flatData) {
-      if (memory?.id && !seenIds.has(memory.id)) {
-        seenIds.add(memory.id);
+      const memoryId = Number(memory?.id);
+      if (memory?.id && !seenIds.has(memoryId)) {
+        seenIds.add(memoryId);
         uniqueMemories.push(normalizeMemory(memory, projectName));
       }
     }

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -11,11 +11,14 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { randomBytes } from "node:crypto";
+import { createLogger } from "./logger";
 import {
   applyProfileReasoningEffort,
   normalizeProfileConfigs,
   updateProfileReasoningEffort,
 } from "./profile-reasoning";
+
+const log = createLogger("profiles");
 import {
   BULK_ASSIGNMENT_MODE,
   BULK_ASSIGNMENT_TARGET,
@@ -175,7 +178,12 @@ export function readProfileModels(profilePath: string): ProfileModels {
   let raw: any;
   try {
     raw = JSON.parse(fs.readFileSync(profilePath, "utf-8"));
-  } catch {
+  } catch (e) {
+    if (e?.code === "ENOENT") {
+      log.debug(`readProfileModels: file does not exist ${profilePath}`);
+    } else {
+      log.warn(`readProfileModels: failed to read or parse ${profilePath}`, e);
+    }
     return {};
   }
 
@@ -213,7 +221,12 @@ export function readProfileFallbackModels(profilePath: string): ProfileFallbackM
   try {
     const raw = JSON.parse(fs.readFileSync(profilePath, "utf-8"));
     return extractSddFallbackModels(raw);
-  } catch {
+  } catch (e) {
+    if (e?.code === "ENOENT") {
+      log.debug(`readProfileFallbackModels: file does not exist ${profilePath}`);
+    } else {
+      log.warn(`readProfileFallbackModels: failed to read or parse ${profilePath}`, e);
+    }
     return {};
   }
 }
@@ -225,7 +238,12 @@ export function readProfileData(profilePath: string): ProfileData {
   try {
     const rawContent = fs.readFileSync(profilePath, "utf-8").toString();
     return readProfileDataFromRaw(rawContent);
-  } catch {
+  } catch (e) {
+    if (e?.code === "ENOENT") {
+      log.debug(`readProfileData: file does not exist ${profilePath}`);
+    } else {
+      log.warn(`readProfileData: failed to read ${profilePath}`, e);
+    }
     return { models: {} };
   }
 }
@@ -234,7 +252,8 @@ function readProfileDataFromRaw(rawContent: string): ProfileData {
   let raw: any;
   try {
     raw = JSON.parse(rawContent);
-  } catch {
+  } catch (e) {
+    log.warn("readProfileDataFromRaw: failed to parse raw profile JSON", e);
     return { models: {} };
   }
 
@@ -311,7 +330,8 @@ function parseVersionId(versionId: string): { profileFile: string; versionFile: 
   const [profileFile, versionFile] = parts;
   try {
     if (profileFile !== safeProfileFileName(profileFile)) throw new Error("Invalid profile version id");
-  } catch {
+  } catch (e) {
+    log.warn(`parseVersionId: invalid profile file segment in ${versionId}`, e);
     throw new Error("Invalid profile version id");
   }
   if (path.basename(versionFile) !== versionFile || !versionFile.endsWith(".json") || versionFile.includes("..")) {
@@ -556,7 +576,8 @@ function readProfilePreviewFromRaw(beforeRaw: string): { models: ProfileModels; 
         : {},
       fallback: extractSddFallbackModels(raw),
     };
-  } catch {
+  } catch (e) {
+    log.warn("readProfilePreviewFromRaw: failed to build preview from raw profile", e);
     return buildEmptyProfilePreview();
   }
 }
@@ -904,7 +925,9 @@ export function detectActiveProfileFile(files: string[], api: any): string | und
         file,
         fallback: readProfileFallbackModels(profilePath),
       });
-    } catch (e) {}
+    } catch (e) {
+      log.warn("findActiveProfileFile: unexpected error while inspecting candidate", e);
+    }
   }
 
   if (primaryMatches.length === 1) {
@@ -1151,7 +1174,12 @@ export function listProfileFiles(): string[] {
   ensureProfilesDir();
   try {
     return fs.readdirSync(profilesDir).filter((f) => isSddProfile(f));
-  } catch {
+  } catch (e) {
+    if (e?.code === "ENOENT") {
+      log.debug(`listProfileFiles: directory does not exist ${profilesDir}`);
+    } else {
+      log.warn(`listProfileFiles: failed to read ${profilesDir}`, e);
+    }
     return [];
   }
 }


### PR DESCRIPTION
Closes #21

## Summary

Adds a minimal structured logger (`src/logger.ts`) and wires it into the previously-silent `catch` blocks listed in the issue, so failures stop being invisible while keeping the public surface unchanged.

- New `createLogger(namespace)` factory exposes `info` / `warn` / `error` / `debug`.
- All output goes to stderr via `console.error` (never stdout) with prefix `[sdd-plugin][<namespace>]`.
- `debug` is silenced by default; `SDD_PLUGIN_DEBUG=1` enables it.
- 11 catches wired across `config.ts` (1), `profiles.ts` (8), `memories.ts` (2). Two raw `console.error` calls in `memories.ts` were migrated to `log.error` for consistency.

## Refinement during smoke-test

In `readProfileModels`, `readProfileFallbackModels`, `readProfileData`, and `listProfileFiles`, `ENOENT` is routed to `log.debug` instead of `log.warn`. These functions implement a deliberate "missing-as-empty" pattern (e.g. `writeProfileModels` calls `readProfileData` first when creating a brand-new profile), so flagging `ENOENT` as a warning produced false alarms during normal use. Real I/O failures and parse errors continue to surface as `log.warn`.

## Justification for scope

The diff is intentionally narrow:
- New file: `src/logger.ts` (~50L) and its test (`src/logger.test.ts`, ~110L).
- Existing files only changed at the import site and at each listed catch — no behavioral change to return values or error propagation.
- `dialogs.tsx` is left untouched (out of scope per the issue — its catches drive user-visible toasts or UI fallbacks).

## Test notes

Validated locally with `npm install && npm test` — 10/10 files, 201/201 tests pass, including 10 new tests for the logger covering levels, prefix, stderr routing, debug env gating (default off, on with `=1`, off with other values, dynamic toggle), and namespace isolation.

Smoke-tested in opencode TUI:
- Creating a new profile → no spurious logs (ENOENT debug-only).
- Corrupted profile JSON → emits `[sdd-plugin][profiles] readProfileModels: failed to read or parse <path>` with the underlying `SyntaxError`.
- `console.error` calls show as `[ERROR]` in opencode's toggle console regardless of internal level, since the logger always uses `console.error` per the AC; this is expected and does not affect stdout.