### PR TITLE
feat: add badge visibility and display mode toggles

### DIFF
--- a/components.test.ts
+++ b/components.test.ts
@@ -1,11 +1,26 @@
 import { describe, expect, it } from 'vitest';
 import { formatActiveModelBadgeText } from './components';
+import type { ActiveProfileState } from './src/types';
+
+const baseProfile: ActiveProfileState = {
+  modelId: 'openai/gpt-5',
+  contextLimit: 400000,
+  providerName: 'OpenAI',
+  modelName: 'GPT-5',
+};
 
 describe('formatActiveModelBadgeText', () => {
+  it('should return placeholder when profile is null', () => {
+    expect(formatActiveModelBadgeText(null)).toBe('No SDD model active');
+  });
+
+  it('should return placeholder when profile is undefined', () => {
+    expect(formatActiveModelBadgeText(undefined)).toBe('No SDD model active');
+  });
+
   it('should include reasoning effort when present', () => {
     const text = formatActiveModelBadgeText({
-      modelName: 'GPT-5',
-      contextLimit: 400000,
+      ...baseProfile,
       reasoningEffort: 'high',
     });
 
@@ -13,11 +28,54 @@ describe('formatActiveModelBadgeText', () => {
   });
 
   it('should omit effort when absent', () => {
+    const text = formatActiveModelBadgeText(baseProfile);
+
+    expect(text).toBe('GPT-5 · 400k ctx');
+  });
+
+  it('should use profile name when display mode is "profile" and profileName is set', () => {
+    const text = formatActiveModelBadgeText(
+      { ...baseProfile, profileName: 'frontend-team' },
+      'profile',
+    );
+
+    expect(text).toBe('frontend-team · 400k ctx');
+  });
+
+  it('should fall back to model name when display mode is "profile" but profileName is missing', () => {
+    const text = formatActiveModelBadgeText(baseProfile, 'profile');
+
+    expect(text).toBe('GPT-5 · 400k ctx');
+  });
+
+  it('should fall back to model name when display mode is "profile" but profileName is blank', () => {
+    const text = formatActiveModelBadgeText(
+      { ...baseProfile, profileName: '   ' },
+      'profile',
+    );
+
+    expect(text).toBe('GPT-5 · 400k ctx');
+  });
+
+  it('should ignore profile name when display mode is "model" (default)', () => {
     const text = formatActiveModelBadgeText({
-      modelName: 'GPT-5',
-      contextLimit: 400000,
+      ...baseProfile,
+      profileName: 'frontend-team',
     });
 
     expect(text).toBe('GPT-5 · 400k ctx');
+  });
+
+  it('should keep effort label when display mode is "profile" and profileName is set', () => {
+    const text = formatActiveModelBadgeText(
+      {
+        ...baseProfile,
+        profileName: 'frontend-team',
+        reasoningEffort: 'high',
+      },
+      'profile',
+    );
+
+    expect(text).toBe('frontend-team · 400k ctx · effort: high');
   });
 });

--- a/components.tsx
+++ b/components.tsx
@@ -1,38 +1,48 @@
 /** @jsxImportSource @opentui/solid */
+import type { ActiveProfileState, BadgeDisplayMode } from "./src/types";
 import { formatContext } from "./src/utils";
 
-export function formatActiveModelBadgeText(profile: any): string {
+export function formatActiveModelBadgeText(
+  profile: ActiveProfileState | null | undefined,
+  displayMode: BadgeDisplayMode = "model",
+): string {
   if (!profile) return "No SDD model active";
+  const profileName =
+    typeof profile.profileName === "string" ? profile.profileName.trim() : "";
+  const useProfileLabel = displayMode === "profile" && profileName.length > 0;
+  const label = useProfileLabel ? profileName : profile.modelName;
   const effortLabel = typeof profile.reasoningEffort === "string" && profile.reasoningEffort.trim()
     ? ` · effort: ${profile.reasoningEffort.trim()}`
     : "";
-  return `${profile.modelName} · ${formatContext(profile.contextLimit)}${effortLabel}`;
+  return `${label} · ${formatContext(profile.contextLimit)}${effortLabel}`;
 }
 
 /**
  * UI Badge component that displays information about the active SDD model
- * 
+ *
  * @param props.profile - The currently active profile state
  * @param props.theme - The current UI theme configuration
+ * @param props.displayMode - "model" (default) shows model info; "profile" shows profile name
  */
-export function ActiveModelBadge(props: { profile: any; theme: any }) {
-  const text = formatActiveModelBadgeText(props.profile);
-
-  const color = props.profile
-    ? (props.theme?.primary || "#00ff00") 
-    : (props.theme?.textMuted || "#888");
-
-  const icon = props.profile ? "󰚩 " : "󱚧 ";
-  const bold = Boolean(props.profile);
-  const textColor = props.theme?.text || "inherit";
-
+export function ActiveModelBadge(props: {
+  profile: ActiveProfileState | null | undefined;
+  theme: any;
+  displayMode?: BadgeDisplayMode;
+}) {
   return (
     <box flexDirection="row" alignItems="center" paddingLeft={1} paddingRight={1}>
-      <text fg={color} attributes={bold ? 1 : 0}>
-        {icon}
+      <text
+        fg={
+          props.profile
+            ? props.theme?.primary || "#00ff00"
+            : props.theme?.textMuted || "#888"
+        }
+        attributes={props.profile ? 1 : 0}
+      >
+        {props.profile ? "󰚩 " : "󱚧 "}
       </text>
-      <text fg={textColor}>
-        {text}
+      <text fg={props.theme?.text || "inherit"}>
+        {formatActiveModelBadgeText(props.profile, props.displayMode)}
       </text>
     </box>
   );

--- a/index.tsx
+++ b/index.tsx
@@ -8,10 +8,13 @@
 
 import * as fs from "node:fs";
 import type { TuiPlugin, TuiPluginModule } from "@opencode-ai/plugin/tui";
-import { createEffect, createRoot } from "solid-js";
+import { Show, createEffect, createRoot, untrack } from "solid-js";
 import { ActiveModelBadge } from "./components";
 import { resolvePaths } from "./src/config";
 import {
+	ACTIVE_PROFILE_NAME_KV_KEY,
+	BADGE_DISPLAY_MODE_KV_KEY,
+	BADGE_VISIBLE_KV_KEY,
 	registerDialogCallbacks,
 	showProfileDetail,
 	showProfileList,
@@ -22,7 +25,15 @@ import { getOrchestratorPolicy } from "./src/orchestrator";
 import { migrateProfilesForRuntimePolicy } from "./src/profiles";
 import { createLogger } from "./src/logger";
 // Direct imports to avoid barrel resolution issues in some environments
-import { activeProfile, setActiveProfile } from "./src/state";
+import {
+	activeProfile,
+	badgeDisplayMode,
+	setActiveProfile,
+	setBadgeDisplayMode,
+	setShowModelBadge,
+	showModelBadge,
+} from "./src/state";
+import type { BadgeDisplayMode } from "./src/types";
 import {
 	parseActiveProfileFromRaw,
 	resolveSessionActiveModel,
@@ -44,18 +55,49 @@ function initializeDialogs() {
 	});
 }
 
+async function readKv(api: any, key: string): Promise<unknown> {
+	try {
+		return await api?.kv?.get?.(key);
+	} catch (error) {
+		log.warn(`readKv: failed to read '${key}'`, error);
+		return undefined;
+	}
+}
+
+function isBadgeDisplayMode(value: unknown): value is BadgeDisplayMode {
+	return value === "model" || value === "profile";
+}
+
+async function loadBadgePreferences(api: any): Promise<void> {
+	const [visible, mode] = await Promise.all([
+		readKv(api, BADGE_VISIBLE_KV_KEY),
+		readKv(api, BADGE_DISPLAY_MODE_KV_KEY),
+	]);
+	const hidden = visible === false || visible === "false";
+	setShowModelBadge(!hidden);
+	setBadgeDisplayMode(isBadgeDisplayMode(mode) ? mode : "model");
+}
+
+async function readPersistedProfileName(api: any): Promise<string | undefined> {
+	const value = await readKv(api, ACTIVE_PROFILE_NAME_KV_KEY);
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
 /**
  * Reads the currently active profile from the local configuration file.
  *
  * @param api - The TUI API instance
  * @returns The active profile state or null if not found/invalid
  */
-function readActiveProfile(api: any) {
+async function readActiveProfile(api: any) {
 	const { configPath } = resolvePaths();
 	try {
 		if (!fs.existsSync(configPath)) return null;
 		const raw = fs.readFileSync(configPath, "utf-8");
-		return parseActiveProfileFromRaw(raw, api);
+		const profile = parseActiveProfileFromRaw(raw, api);
+		if (!profile) return null;
+		const profileName = await readPersistedProfileName(api);
+		return profileName ? { ...profile, profileName } : profile;
 	} catch (error) {
 		log.warn(`readActiveProfile: failed to read ${configPath}`, error);
 		return null;
@@ -113,19 +155,25 @@ function registerSlots(api: any) {
 						const sessionId =
 							route.name === "session" ? route.params?.sessionID : undefined;
 						return (
-							<ActiveModelBadge
-								profile={resolveDisplayedModel(api, sessionId)}
-								theme={ctx.theme.current}
-							/>
+							<Show when={showModelBadge()}>
+								<ActiveModelBadge
+									profile={resolveDisplayedModel(api, sessionId)}
+									theme={ctx.theme.current}
+									displayMode={badgeDisplayMode()}
+								/>
+							</Show>
 						);
 					});
 				},
 				sidebar_content(ctx: any) {
 					return renderSlot(api, () => (
-						<ActiveModelBadge
-							profile={resolveDisplayedModel(api, ctx.session_id)}
-							theme={ctx.theme.current}
-						/>
+						<Show when={showModelBadge()}>
+							<ActiveModelBadge
+								profile={resolveDisplayedModel(api, ctx.session_id)}
+								theme={ctx.theme.current}
+								displayMode={badgeDisplayMode()}
+							/>
+						</Show>
 					));
 				},
 			},
@@ -151,8 +199,10 @@ const tui: TuiPlugin = async (api) => {
 	);
 	migrateProfilesForRuntimePolicy(runtimePolicy);
 
+	await loadBadgePreferences(api);
+
 	// Load and set the active profile in the global state
-	const profile = readActiveProfile(api);
+	const profile = await readActiveProfile(api);
 	setActiveProfile(profile);
 
 	// Keep the active profile in sync with global config changes.
@@ -160,11 +210,16 @@ const tui: TuiPlugin = async (api) => {
 		api.lifecycle.onDispose(dispose);
 		createEffect(() => {
 			const currentConfig = api.state.config;
-			if (currentConfig) {
-				setActiveProfile(
-					parseActiveProfileFromRaw(JSON.stringify(currentConfig), api),
-				);
+			if (!currentConfig) return;
+			const next = parseActiveProfileFromRaw(JSON.stringify(currentConfig), api);
+			if (!next) {
+				setActiveProfile(null);
+				return;
 			}
+			const previousProfileName = untrack(() => activeProfile()?.profileName);
+			setActiveProfile(
+				previousProfileName ? { ...next, profileName: previousProfileName } : next,
+			);
 		});
 	});
 

--- a/src/dialogs.tsx
+++ b/src/dialogs.tsx
@@ -16,6 +16,7 @@ import {
   ProfileVersion,
   ProfileVersionMetadata,
   NAV_CATEGORY,
+  type BadgeDisplayMode,
 } from "./types";
 import {
   resolveModelInfo,
@@ -45,9 +46,19 @@ import {
 } from "./profiles";
 import { buildReasoningEditState, updateProfileReasoningEffort } from "./profile-reasoning";
 import { deleteProjectMemory, listProjectMemories } from "./memories";
-import { setActiveProfile } from "./state";
+import {
+  badgeDisplayMode,
+  setActiveProfile,
+  setBadgeDisplayMode,
+  setShowModelBadge,
+  showModelBadge,
+} from "./state";
 import { createLogger } from "./logger";
 import { canonicalizeProfileModels, getOrchestratorPolicy, type OrchestratorPolicy } from "./orchestrator";
+
+export const BADGE_VISIBLE_KV_KEY = "sdd-show-model-badge";
+export const BADGE_DISPLAY_MODE_KV_KEY = "sdd-badge-display-mode";
+export const ACTIVE_PROFILE_NAME_KV_KEY = "sdd-active-profile-name";
 
 const log = createLogger("dialogs");
 
@@ -496,6 +507,16 @@ export function showProfilesMenu(api: any) {
           description: "Show recent Engram observations for this project.",
         },
         {
+          title: `Badge: ${showModelBadge() ? "On" : "Off"}`,
+          value: "toggle_badge_visible",
+          description: "Show or hide the badge.",
+        },
+        {
+          title: `Badge mode: ${badgeDisplayMode() === "profile" ? "Profile" : "Model"}`,
+          value: "toggle_badge_mode",
+          description: "Show model info or active profile name on the badge.",
+        },
+        {
           title: "✕ Close",
           value: "__close__",
           category: NAV_CATEGORY,
@@ -505,7 +526,21 @@ export function showProfilesMenu(api: any) {
         if (opt.value === "create") showCreateProfile(api);
         else if (opt.value === "list") showProfileListFn(api);
         else if (opt.value === "view_memories") showProjectMemoriesMenuFn(api);
-        else api.ui.dialog.clear();
+        else if (opt.value === "toggle_badge_visible") {
+          const next = !showModelBadge();
+          setShowModelBadge(next);
+          Promise.resolve().then(() => api.kv.set(BADGE_VISIBLE_KV_KEY, next)).catch((e) => {
+            log.warn(`toggle_badge_visible: failed to persist '${BADGE_VISIBLE_KV_KEY}'`, e);
+          });
+          showProfilesMenu(api);
+        } else if (opt.value === "toggle_badge_mode") {
+          const next: BadgeDisplayMode = badgeDisplayMode() === "model" ? "profile" : "model";
+          setBadgeDisplayMode(next);
+          Promise.resolve().then(() => api.kv.set(BADGE_DISPLAY_MODE_KV_KEY, next)).catch((e) => {
+            log.warn(`toggle_badge_mode: failed to persist '${BADGE_DISPLAY_MODE_KV_KEY}'`, e);
+          });
+          showProfilesMenu(api);
+        } else api.ui.dialog.clear();
       }}
       onCancel={() => api.ui.dialog.clear()}
     />
@@ -822,8 +857,15 @@ async function handleActivateProfile(api: any, profilePath: string, profileName:
   const updatedConfig = await activateProfileFile(api, profilePath, profileName);
   if (!updatedConfig) return;
 
-  // Sync global state after activation
-  setActiveProfile(parseActiveProfileFromRaw(JSON.stringify(updatedConfig), api));
+  try {
+    await api.kv.set(ACTIVE_PROFILE_NAME_KV_KEY, profileName);
+  } catch (e) {
+    log.warn(`handleActivateProfile: failed to persist active profile name`, e);
+  }
+
+  // Sync global state after activation; attach profileName so the badge can render it.
+  const next = parseActiveProfileFromRaw(JSON.stringify(updatedConfig), api);
+  setActiveProfile(next ? { ...next, profileName } : next);
 
   api.ui.dialog.replace(() => (
     <api.ui.DialogConfirm

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,22 +1,34 @@
 /** @jsxImportSource @opentui/solid */
 import { createSignal } from "solid-js";
-import { ActiveProfileState } from "./types";
+import type { ActiveProfileState, BadgeDisplayMode } from "./types";
 
 /**
  * The currently active profile state signal
  */
 const [activeProfileSignal, setActiveProfileSignal] = createSignal<ActiveProfileState | null>(null);
+const [showModelBadgeSignal, setShowModelBadgeSignal] = createSignal<boolean>(true);
+const [badgeDisplayModeSignal, setBadgeDisplayModeSignal] = createSignal<BadgeDisplayMode>("model");
 
 /**
  * Getter for the active profile state
  */
 export const activeProfile = activeProfileSignal;
+export const showModelBadge = showModelBadgeSignal;
+export const badgeDisplayMode = badgeDisplayModeSignal;
 
 /**
  * Updates the global active profile state
- * 
+ *
  * @param profile - The new profile state or null to clear it
  */
 export function setActiveProfile(profile: ActiveProfileState | null): void {
   setActiveProfileSignal(profile);
+}
+
+export function setShowModelBadge(value: boolean): void {
+  setShowModelBadgeSignal(value);
+}
+
+export function setBadgeDisplayMode(mode: BadgeDisplayMode): void {
+  setBadgeDisplayModeSignal(mode);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,8 +11,11 @@ export type ActiveProfileState = {
   contextLimit: number | null;
   providerName: string;
   modelName: string;
+  profileName?: string;
   reasoningEffort?: string;
 };
+
+export type BadgeDisplayMode = "model" | "profile";
 
 /**
  * Mapping of profile names to their model identifiers


### PR DESCRIPTION
## Summary

- Add a toggle to show/hide the active model badge (#23).
- Add a display mode toggle so the badge can show the active model info or the active profile name (#25).
- Persist both preferences and the active profile name via `api.kv`.

## Linked Issue

Closes #23
Closes #25

## Scope Justification

Strictly the minimum viable change for both issues:

- `src/state.ts` — two new signals: `showModelBadge`, `badgeDisplayMode`.
- `src/types.ts` — `BadgeDisplayMode` type + optional `profileName` on `ActiveProfileState`.
- `src/dialogs.tsx` — two new menu entries + handlers; `api.kv.set("sdd-active-profile-name", ...)` on profile activation.
- `index.tsx` — read persisted preferences on startup; reuse the existing `createEffect` to attach `profileName` to state (no rework, no replacement).
- `components.tsx` — `formatActiveModelBadgeText` accepts optional `profileName` and falls back to model info when unset.
- `components.test.ts` — coverage for all combinations (mode × null/undefined × effort).

No file detection, no reconciliation, no snapshot serialization, no reactive rework. Hardening that came up during review is queued as separate follow-ups (not included).

## Validation

- `npm run typecheck` clean
- `npm test` 213/213 green
- Manual TUI verification: toggle visible/off + mode switch + persistence across restarts

## Checklist

- [x] I linked an issue
- [x] I kept the change as small and focused as possible
- [x] I explained the scope
- [x] I included validation notes