### PR TITLE
fix: degradar slots cuando el host no expone el renderer

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -22,6 +22,7 @@ import {
 	showProfilesMenu,
 	showProjectMemoriesMenu,
 } from "./src/dialogs";
+import { getHostVersion, safeSlotRender } from "./src/host-compat";
 import { createLogger } from "./src/logger";
 import { getOrchestratorPolicy } from "./src/orchestrator";
 import { migrateProfilesForRuntimePolicy } from "./src/profiles";
@@ -158,10 +159,10 @@ function registerProfilesCommand(api: any) {
 	});
 }
 
-function renderSlot(api: any, render: () => any) {
+function renderSlot(api: any, label: string, render: () => any) {
 	return createRoot((dispose) => {
 		api.lifecycle.onDispose(dispose);
-		return render();
+		return safeSlotRender(label, render);
 	});
 }
 
@@ -172,7 +173,7 @@ function registerSlots(api: any) {
 		api.slots.register({
 			slots: {
 				home_bottom(ctx: any) {
-					return renderSlot(api, () => {
+					return renderSlot(api, "home_bottom", () => {
 						const route = api.route.current;
 						const sessionId =
 							route.name === "session" ? route.params?.sessionID : undefined;
@@ -188,7 +189,7 @@ function registerSlots(api: any) {
 					});
 				},
 				sidebar_content(ctx: any) {
-					return renderSlot(api, () => (
+					return renderSlot(api, "sidebar_content", () => (
 						<Show when={showModelBadge()}>
 							<ActiveModelBadge
 								profile={resolveDisplayedModel(api, ctx.session_id)}
@@ -212,6 +213,8 @@ const id = "sdd-model-select";
  * Registers commands and UI slots for the plugin
  */
 const tui: TuiPlugin = async (api) => {
+	log.info(`host opencode v${getHostVersion(api)}`);
+
 	// Initialize dialog callbacks
 	initializeDialogs();
 

--- a/src/host-compat.test.ts
+++ b/src/host-compat.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getHostVersion,
+  resetHostCompatStateForTests,
+  safeSlotRender,
+} from "./host-compat";
+
+describe("host-compat", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    resetHostCompatStateForTests();
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe("getHostVersion", () => {
+    it("returns the version from api.app.version", () => {
+      expect(getHostVersion({ app: { version: "1.14.49" } })).toBe("1.14.49");
+    });
+
+    it("returns 'unknown' when app is missing", () => {
+      expect(getHostVersion({})).toBe("unknown");
+    });
+
+    it("returns 'unknown' when version is missing", () => {
+      expect(getHostVersion({ app: {} })).toBe("unknown");
+    });
+  });
+
+  describe("safeSlotRender", () => {
+    it("returns the render result when nothing throws", () => {
+      const result = safeSlotRender("home_bottom", () => "ok");
+      expect(result).toBe("ok");
+    });
+
+    it("returns null when the renderer is missing", () => {
+      const result = safeSlotRender("home_bottom", () => {
+        throw new Error("No renderer found");
+      });
+      expect(result).toBeNull();
+    });
+
+    it("warns once across multiple incompatible renders", () => {
+      safeSlotRender("home_bottom", () => {
+        throw new Error("No renderer found");
+      });
+      safeSlotRender("sidebar_content", () => {
+        throw new Error("No renderer found");
+      });
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("rethrows errors unrelated to the renderer", () => {
+      expect(() =>
+        safeSlotRender("home_bottom", () => {
+          throw new Error("something else");
+        }),
+      ).toThrow("something else");
+    });
+
+    it("rethrows non-Error throwables", () => {
+      expect(() =>
+        safeSlotRender("home_bottom", () => {
+          throw "string error";
+        }),
+      ).toThrow("string error");
+    });
+  });
+});

--- a/src/host-compat.ts
+++ b/src/host-compat.ts
@@ -1,0 +1,41 @@
+import { createLogger } from "./logger";
+
+const log = createLogger("host-compat");
+
+const RENDERER_MISSING_MESSAGE = "No renderer found";
+
+export interface HostApi {
+  app?: { version?: string };
+}
+
+let rendererMissingReported = false;
+
+export function getHostVersion(api: HostApi): string {
+  return api?.app?.version ?? "unknown";
+}
+
+export function safeSlotRender<T>(label: string, render: () => T): T | null {
+  try {
+    return render();
+  } catch (error) {
+    if (isRendererMissing(error)) {
+      if (!rendererMissingReported) {
+        rendererMissingReported = true;
+        log.warn(
+          `slot '${label}' disabled: host TUI did not expose a Solid renderer. ` +
+            "Pin opencode to a compatible version or upgrade opencode-sdd-engram-manage.",
+        );
+      }
+      return null;
+    }
+    throw error;
+  }
+}
+
+function isRendererMissing(error: unknown): boolean {
+  return error instanceof Error && error.message === RENDERER_MISSING_MESSAGE;
+}
+
+export function resetHostCompatStateForTests(): void {
+  rendererMissingReported = false;
+}


### PR DESCRIPTION
# fix: degradar slots cuando el host no expone el renderer

## :fire: Qué cambia:

Con opencode `1.14.50`, los slots `home_bottom` y `sidebar_content` tiran `Error: No renderer found` en el primer render y eso crashea la TUI entera con el overlay de fatal error.

Cambios:

* `safeSlotRender(label, render)` envuelve el render del slot. Si cae `Error("No renderer found")` devuelve `null` (el slot queda inactivo) y se loguea un warning una sola vez con un mensaje accionable. Cualquier otro error se re-lanza tal cual.
* `getHostVersion(api)` y un `log.info` con la versión del host al iniciar, para que los reportes traigan ese dato sin pedirlo.

Comandos (`:sdd-model`), keybindings y persistencia siguen funcionando. Se pierde solo el badge visual hasta que se restablezca la compatibilidad.

## :wrench: Alcance:

Es un fix defensivo, no la causa raíz. El throw viene de tener dos instancias de `@opentui/solid` en memoria (la del host y la que resuelve el loader del plugin), entonces el `RendererContext` del host no es visible para el `useContext` del plugin. Arreglar eso de fondo requiere cambios upstream. Este PR evita que el mismatch mate la TUI mientras tanto.

## :male_detective: QA Testing:

1. Instalar opencode `1.14.50`.
2. Apuntar `~/.config/opencode/tui.json` al plugin compilado de esta branch.
3. Iniciar opencode: no crashea. En stderr aparece:

   ```
   [sdd-plugin][host-compat] slot 'home_bottom' disabled: host TUI did not expose a Solid renderer. Pin opencode to a compatible version or upgrade opencode-sdd-engram-manage.
   ```

4. Ejecutar `:sdd-model` con `alt+k`: el menú abre.
5. Volver a opencode `1.14.49` y reiniciar: el badge renderiza normal sin warnings.

Local:

```
npm run typecheck
npm test         # 223 passed
npm run build
```