### PR TITLE
fix: normalize variant bodies for reasoning effort selection

### DIFF
--- a/docs/profile-reasoning-effort.md
+++ b/docs/profile-reasoning-effort.md
@@ -14,7 +14,7 @@ This document captures what we verified in opencode runtime metadata and what we
 |---|---|
 | Model source | The plugin reads provider/model metadata from `api.state.provider[].models`. |
 | Capability signal | Models expose `capabilities.reasoning`. |
-| Effort source | Valid effort values come from `model.variants[*].reasoningEffort`, not from a flat `effort` field. |
+| Effort source | Valid effort values are normalized from variant bodies: `reasoningEffort`, `reasoning.effort`, `thinkingConfig.thinkingLevel`, or known variant keys (`low`, `medium`, `high`, etc.). |
 | Variability | Not all models expose the same effort set; some include `none`, others start at `low`. |
 | Fallback scope | The requested feature should apply only to primary agents, not fallback agents. |
 
@@ -44,13 +44,13 @@ This document captures what we verified in opencode runtime metadata and what we
 - Add a new action such as `Edit reasoning effort` for primary agents.
 - Resolve the currently assigned `provider/model`.
 - Read runtime metadata from `api.state.provider`.
-- If the model supports reasoning and exposes variants with `reasoningEffort`, show only those valid options.
+- If the model supports reasoning and exposes parseable variant metadata, show only those valid options.
 - If the model does not support reasoning effort, show a notification and do not persist invalid config.
 
 ### Activation
 
 - Apply `model` exactly as today.
-- Apply `configs[agent].reasoningEffort` only for primary agents.
+- Apply `configs[agent].reasoningEffort` only for primary agents by resolving the matching opencode variant key and setting `agent.variant`.
 - Do not apply reasoning effort to generated fallback agents unless explicitly designed later.
 
 ## Proposed runtime decision rules
@@ -59,7 +59,7 @@ This document captures what we verified in opencode runtime metadata and what we
 |---|---|
 | No model assigned | Do not show the effort picker; explain that a primary model must be selected first. |
 | `capabilities.reasoning !== true` | Show a warning that the selected model does not support reasoning effort. |
-| No variants with `reasoningEffort` | Show a warning that no effort variants are available for that model. |
+| No parseable variant metadata | Show a warning that no effort variants are available for that model. |
 | Variants available | Derive selectable options dynamically from runtime metadata. |
 
 ## Risks and constraints

--- a/src/profile-reasoning.test.ts
+++ b/src/profile-reasoning.test.ts
@@ -55,6 +55,69 @@ describe("profile reasoning helpers", () => {
       const noMetadata = buildReasoningEditState(providers as any, "sdd-apply", "openai/unknown");
       expect(noMetadata).toEqual({ kind: "unsupported", agentName: "sdd-apply", modelId: "openai/unknown" });
     });
+
+    it("returns selectable options for nested OpenRouter reasoning.effort variants", () => {
+      const openRouterProviders = [
+        {
+          id: "openrouter",
+          models: {
+            "google/gemini-3.1-pro-preview": {
+              capabilities: { reasoning: true },
+              variants: {
+                low: { reasoning: { effort: "low" } },
+                medium: { reasoning: { effort: "medium" } },
+                high: { reasoning: { effort: "high" } },
+              },
+            },
+          },
+        },
+      ];
+
+      const state = buildReasoningEditState(
+        openRouterProviders as any,
+        "sdd-apply",
+        "openrouter/google/gemini-3.1-pro-preview",
+        "medium",
+      );
+
+      expect(state).toEqual({
+        kind: "selectable",
+        agentName: "sdd-apply",
+        modelId: "openrouter/google/gemini-3.1-pro-preview",
+        options: ["high", "low", "medium"],
+        current: "medium",
+      });
+    });
+
+    it("returns selectable options for Google thinkingConfig variants", () => {
+      const googleProviders = [
+        {
+          id: "google",
+          models: {
+            "gemini-3.1-flash-lite": {
+              capabilities: { reasoning: true },
+              variants: {
+                low: { thinkingConfig: { thinkingLevel: "low" } },
+                high: { thinkingConfig: { thinkingLevel: "high" } },
+              },
+            },
+          },
+        },
+      ];
+
+      const state = buildReasoningEditState(
+        googleProviders as any,
+        "sdd-init",
+        "google/gemini-3.1-flash-lite",
+      );
+
+      expect(state).toEqual({
+        kind: "selectable",
+        agentName: "sdd-init",
+        modelId: "google/gemini-3.1-flash-lite",
+        options: ["high", "low"],
+      });
+    });
   });
 
   describe("normalizeProfileConfigs", () => {
@@ -140,6 +203,37 @@ describe("profile reasoning helpers", () => {
       },
     ];
 
+    it("applies OpenRouter variant keys from nested reasoning.effort metadata", () => {
+      const openRouterProviders = [
+        {
+          id: "openrouter",
+          models: {
+            "google/gemini-3.1-pro-preview": {
+              capabilities: { reasoning: true },
+              variants: {
+                low: { reasoning: { effort: "low" } },
+                medium: { reasoning: { effort: "medium" } },
+                high: { reasoning: { effort: "high" } },
+              },
+            },
+          },
+        },
+      ];
+
+      const next = applyProfileReasoningEffort({
+        agent: {
+          "sdd-apply": { model: "openrouter/google/gemini-3.1-pro-preview", options: {} },
+        },
+      }, {
+        models: { "sdd-apply": "openrouter/google/gemini-3.1-pro-preview" },
+        configs: { "sdd-apply": { reasoningEffort: "high" } },
+      } as any, openRouterProviders as any);
+
+      expect(next.config.agent["sdd-apply"].variant).toBe("high");
+      expect(next.appliedAgents).toEqual(["sdd-apply"]);
+      expect(next.warnings).toEqual([]);
+    });
+
     it("applies only valid primary reasoning values", () => {
       const next = applyProfileReasoningEffort({
         agent: {
@@ -154,9 +248,9 @@ describe("profile reasoning helpers", () => {
         },
       } as any, providers as any);
 
-      expect(next.config.agent["sdd-apply"].reasoningEffort).toBe("high");
-      expect(next.config.agent["sdd-apply"].options.reasoningEffort).toBe("high");
-      expect(next.config.agent["sdd-apply-fallback"].reasoningEffort).toBeUndefined();
+      expect(next.config.agent["sdd-apply"].variant).toBe("high");
+      expect(next.config.agent["sdd-apply"].reasoningEffort).toBeUndefined();
+      expect(next.config.agent["sdd-apply-fallback"].variant).toBeUndefined();
       expect(next.appliedAgents).toEqual(["sdd-apply"]);
       expect(next.clearedAgents).toEqual([]);
       expect(next.warnings).toEqual([]);
@@ -174,8 +268,8 @@ describe("profile reasoning helpers", () => {
 
       expect(stale.appliedAgents).toEqual([]);
       expect(stale.clearedAgents).toEqual(["sdd-apply"]);
+      expect(stale.config.agent["sdd-apply"].variant).toBeUndefined();
       expect(stale.config.agent["sdd-apply"].reasoningEffort).toBeUndefined();
-      expect(stale.config.agent["sdd-apply"].options.reasoningEffort).toBeUndefined();
       expect(stale.warnings[0]).toContain("incompatible");
 
       const missingMetadata = applyProfileReasoningEffort({
@@ -189,8 +283,8 @@ describe("profile reasoning helpers", () => {
 
       expect(missingMetadata.appliedAgents).toEqual([]);
       expect(missingMetadata.clearedAgents).toEqual(["sdd-apply"]);
+      expect(missingMetadata.config.agent["sdd-apply"].variant).toBeUndefined();
       expect(missingMetadata.config.agent["sdd-apply"].reasoningEffort).toBeUndefined();
-      expect(missingMetadata.config.agent["sdd-apply"].options.reasoningEffort).toBeUndefined();
       expect(missingMetadata.warnings[0]).toContain("metadata");
     });
 
@@ -205,7 +299,7 @@ describe("profile reasoning helpers", () => {
         configs: { "sdd-orchestrator": { reasoningEffort: "high" } },
       } as any, providers as any, policy);
 
-      expect(next.config.agent["gentle-orchestrator"].reasoningEffort).toBe("high");
+      expect(next.config.agent["gentle-orchestrator"].variant).toBe("high");
       expect(next.config.agent["sdd-orchestrator"]).toBeUndefined();
       expect(next.appliedAgents).toEqual(["gentle-orchestrator"]);
       expect(next.clearedAgents).toEqual([]);
@@ -222,7 +316,7 @@ describe("profile reasoning helpers", () => {
         configs: { "gentle-orchestrator": { reasoningEffort: "low" } },
       } as any, providers as any, policy);
 
-      expect(next.config.agent["sdd-orchestrator"].reasoningEffort).toBe("low");
+      expect(next.config.agent["sdd-orchestrator"].variant).toBe("low");
       expect(next.config.agent["gentle-orchestrator"]).toBeUndefined();
       expect(next.appliedAgents).toEqual(["sdd-orchestrator"]);
       expect(next.clearedAgents).toEqual([]);
@@ -242,10 +336,10 @@ describe("profile reasoning helpers", () => {
         },
       } as any, providers as any);
 
+      expect(next.config.agent["sdd-init"].variant).toBeUndefined();
       expect(next.config.agent["sdd-init"].reasoningEffort).toBeUndefined();
-      expect(next.config.agent["sdd-init"].options.reasoningEffort).toBeUndefined();
+      expect(next.config.agent["sdd-apply"].variant).toBeUndefined();
       expect(next.config.agent["sdd-apply"].reasoningEffort).toBeUndefined();
-      expect(next.config.agent["sdd-apply"].options.reasoningEffort).toBeUndefined();
       expect(next.config.agent["sdd-plan"].reasoningEffort).toBe("medium");
       expect(next.appliedAgents).toEqual([]);
       expect(next.clearedAgents.sort()).toEqual(["sdd-apply", "sdd-init"]);
@@ -264,8 +358,8 @@ describe("profile reasoning helpers", () => {
         },
       } as any, providers as any, policy);
 
+      expect(next.config.agent["gentle-orchestrator"].variant).toBeUndefined();
       expect(next.config.agent["gentle-orchestrator"].reasoningEffort).toBeUndefined();
-      expect(next.config.agent["gentle-orchestrator"].options.reasoningEffort).toBeUndefined();
       expect(next.config.agent["sdd-orchestrator"]).toBeUndefined();
       expect(next.appliedAgents).toEqual([]);
       expect(next.clearedAgents).toEqual(["gentle-orchestrator"]);

--- a/src/profile-reasoning.ts
+++ b/src/profile-reasoning.ts
@@ -9,6 +9,13 @@ import {
   type OrchestratorPolicy,
 } from "./orchestrator";
 
+const KNOWN_EFFORT_TOKENS = new Set(["none", "minimal", "low", "medium", "high", "xhigh", "max"]);
+
+type ModelVariantOption = {
+  key: string;
+  effort: string;
+};
+
 function resolveModelDefinition(providers: any[], modelId: string): any | null {
   if (!modelId || typeof modelId !== "string") return null;
   const [providerId, ...rest] = modelId.split("/");
@@ -18,14 +25,63 @@ function resolveModelDefinition(providers: any[], modelId: string): any | null {
   return provider?.models?.[modelKey] || null;
 }
 
-function listReasoningEffortsFromModel(modelDef: any): string[] {
+function extractEffortFromVariantBody(variant: any, variantKey: string): string | null {
+  if (!variant || typeof variant !== "object" || variant.disabled === true) return null;
+
+  if (typeof variant.reasoningEffort === "string") {
+    const trimmed = variant.reasoningEffort.trim();
+    if (trimmed) return trimmed;
+  }
+
+  if (typeof variant.reasoning?.effort === "string") {
+    const trimmed = variant.reasoning.effort.trim();
+    if (trimmed) return trimmed;
+  }
+
+  if (typeof variant.thinkingConfig?.thinkingLevel === "string") {
+    const trimmed = variant.thinkingConfig.thinkingLevel.trim();
+    if (trimmed) return trimmed;
+  }
+
+  const normalizedKey = variantKey.trim().toLowerCase();
+  if (KNOWN_EFFORT_TOKENS.has(normalizedKey)) return normalizedKey;
+
+  return null;
+}
+
+function listModelVariantOptions(modelDef: any): ModelVariantOption[] {
   if (!modelDef || modelDef?.capabilities?.reasoning !== true) return [];
   const variants = modelDef?.variants;
   if (!variants || typeof variants !== "object") return [];
-  const values = Object.values(variants)
-    .map((variant: any) => (typeof variant?.reasoningEffort === "string" ? variant.reasoningEffort.trim() : ""))
-    .filter(Boolean);
+
+  const options: ModelVariantOption[] = [];
+  for (const [key, variant] of Object.entries(variants)) {
+    const effort = extractEffortFromVariantBody(variant, key);
+    if (effort) options.push({ key, effort });
+  }
+  return options;
+}
+
+function listReasoningEffortsFromModel(modelDef: any): string[] {
+  const values = listModelVariantOptions(modelDef).map((option) => option.effort);
   return Array.from(new Set(values)).sort();
+}
+
+function resolveVariantKeyForEffort(modelDef: any, effort: string): string | null {
+  const matches = listModelVariantOptions(modelDef).filter((option) => option.effort === effort);
+  if (matches.length === 0) return null;
+
+  const keyMatch = matches.find((option) => option.key.toLowerCase() === effort.toLowerCase());
+  return (keyMatch || matches[0]).key;
+}
+
+export function resolveEffortFromAgentVariant(providers: any[], modelId: string, variantKey?: string): string | undefined {
+  if (typeof variantKey !== "string" || !variantKey.trim()) return undefined;
+  const modelDef = resolveModelDefinition(providers, modelId);
+  if (!modelDef) return undefined;
+
+  const option = listModelVariantOptions(modelDef).find((entry) => entry.key === variantKey.trim());
+  return option?.effort;
 }
 
 export function buildReasoningEditState(
@@ -113,21 +169,23 @@ export function updateProfileReasoningEffort(profile: ProfileData, agentName: st
 
 function clearAgentReasoningEffort(agentConfig: any) {
   if (!agentConfig || typeof agentConfig !== "object") return;
+  delete agentConfig.variant;
   delete agentConfig.reasoningEffort;
   if (agentConfig.options && typeof agentConfig.options === "object") {
     delete agentConfig.options.reasoningEffort;
   }
 }
 
-function applyAgentReasoningEffort(agentConfig: any, effort: string) {
+function applyAgentReasoningEffort(agentConfig: any, variantKey: string) {
   const next = {
     ...(agentConfig || {}),
-    reasoningEffort: effort,
-    options: {
-      ...((agentConfig && typeof agentConfig.options === "object") ? agentConfig.options : {}),
-      reasoningEffort: effort,
-    },
+    variant: variantKey,
   };
+  delete next.reasoningEffort;
+  if (next.options && typeof next.options === "object") {
+    const { reasoningEffort: _removed, ...restOptions } = next.options;
+    next.options = restOptions;
+  }
   return next;
 }
 
@@ -194,8 +252,18 @@ export function applyProfileReasoningEffort(currentConfig: any, profile: Profile
       continue;
     }
 
+    const variantKey = resolveVariantKeyForEffort(modelDef, effort);
+    if (!variantKey) {
+      if (nextConfig?.agent?.[agentName] && typeof nextConfig.agent[agentName] === "object") {
+        clearAgentReasoningEffort(nextConfig.agent[agentName]);
+        clearedAgents.push(agentName);
+      }
+      warnings.push(`Skipped reasoning effort for ${agentName}: no variant key resolved for '${effort}' on ${modelId}.`);
+      continue;
+    }
+
     if (!nextConfig.agent) nextConfig.agent = {};
-    nextConfig.agent[agentName] = applyAgentReasoningEffort(nextConfig.agent[agentName], effort);
+    nextConfig.agent[agentName] = applyAgentReasoningEffort(nextConfig.agent[agentName], variantKey);
     appliedAgents.push(agentName);
   }
 

--- a/src/profiles.test.ts
+++ b/src/profiles.test.ts
@@ -2235,9 +2235,9 @@ describe('profiles logic', () => {
       await activateProfileFile(api, '/mock/profiles/team.json', 'team');
 
       const payload = update.mock.calls[0]?.[0]?.config;
-      expect(payload.agent['sdd-init']?.reasoningEffort).toBe('high');
-      expect(payload.agent['sdd-apply']?.reasoningEffort).toBeUndefined();
-      expect(payload.agent['sdd-init-fallback']?.reasoningEffort).toBeUndefined();
+      expect(payload.agent['sdd-init']?.variant).toBe('high');
+      expect(payload.agent['sdd-apply']?.variant).toBeUndefined();
+      expect(payload.agent['sdd-init-fallback']?.variant).toBeUndefined();
       expect(toast).toHaveBeenCalledWith(expect.objectContaining({
         title: 'Activation Warning',
         variant: 'warning',
@@ -2294,7 +2294,7 @@ describe('profiles logic', () => {
       await activateProfileFile(api, '/mock/profiles/team.json', 'team');
 
       const payload = update.mock.calls[0]?.[0]?.config;
-      expect(payload.agent['gentle-orchestrator']?.reasoningEffort).toBe('high');
+      expect(payload.agent['gentle-orchestrator']?.variant).toBe('high');
       expect(payload.agent['sdd-orchestrator']).toBeUndefined();
     });
 
@@ -2348,7 +2348,7 @@ describe('profiles logic', () => {
       await activateProfileFile(api, '/mock/profiles/team.json', 'team');
 
       const payload = update.mock.calls[0]?.[0]?.config;
-      expect(payload.agent['sdd-orchestrator']?.reasoningEffort).toBe('low');
+      expect(payload.agent['sdd-orchestrator']?.variant).toBe('low');
       expect(payload.agent['gentle-orchestrator']).toBeUndefined();
     });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@
 
 import { ActiveProfileState } from "./types";
 import { getOrchestratorPolicy } from "./orchestrator";
+import { resolveEffortFromAgentVariant } from "./profile-reasoning";
 import { createLogger } from "./logger";
 
 const log = createLogger("utils");
@@ -134,7 +135,9 @@ function resolveAgentModelState(api: any, agentName?: string, fallbackModel?: { 
   if (agentName) {
     const agentConfig = api.state.config?.agent?.[agentName] || {};
     const configuredModelId = agentConfig?.model;
-    const reasoningEffort = agentConfig?.reasoningEffort;
+    const reasoningEffort =
+      agentConfig?.reasoningEffort ||
+      resolveEffortFromAgentVariant(api.state.provider || [], configuredModelId, agentConfig?.variant);
     if (typeof configuredModelId === "string" && configuredModelId) {
       const [providerId, ...rest] = configuredModelId.split("/");
       const modelKey = rest.join("/");
@@ -209,7 +212,10 @@ export function parseActiveProfileFromRaw(raw: string, api: any): ActiveProfileS
       agentNames[0];
 
     const modelId = agentConfigs[firstAgent]?.model;
-    const reasoningEffort = agentConfigs[firstAgent]?.reasoningEffort;
+    const agentEntry = agentConfigs[firstAgent] || {};
+    const reasoningEffort =
+      agentEntry.reasoningEffort ||
+      resolveEffortFromAgentVariant(api.state.provider || [], modelId, agentEntry.variant);
     if (!modelId) return null;
 
     const [providerId, ...rest] = modelId.split("/");


### PR DESCRIPTION
## Summary

- Normalize opencode variant metadata from multiple body shapes (`reasoningEffort`, `reasoning.effort`, `thinkingConfig.thinkingLevel`, known variant keys).
- Apply saved profile reasoning effort via `agent.variant` instead of the non-standard `reasoningEffort` agent field.
- Resolve effort labels from `agent.variant` for status display.

Fixes OpenRouter models (e.g. Gemini 3.1 Pro preview) being incorrectly reported as unsupported in the reasoning effort picker.

Closes #36

## Image proofs:
#### 1. The high variant is set with `/variants`.
<img width="1512" height="888" alt="Screenshot 2026-06-13 at 7 30 44 PM" src="https://github.com/user-attachments/assets/98bae10f-f44f-4b68-ac7c-314cdaf284c7" />


####  2. The variant can be selected from the list, but it cannot be edited.  
<img width="1502" height="891" alt="Screenshot 2026-06-13 at 7 31 23 PM" src="https://github.com/user-attachments/assets/bf6c875f-b265-449e-902f-355d4ddf7e18" />


#### 3. The main problem is that it is not possible to select variants for subagents.
<img width="1501" height="888" alt="Screenshot 2026-06-13 at 7 31 31 PM" src="https://github.com/user-attachments/assets/d0d6d31e-b95c-4a92-8ec6-ac928272dcf1" />


## Scope Justification

Changes are limited to variant detection/application (`profile-reasoning.ts`), display resolution (`utils.ts`), tests, and docs.

## Validation

- Tests run: `npm test` (232 passed)
- Manual verification: assign `openrouter/google/gemini-3.1-pro-preview`, open **Reasoning effort...**, confirm low/medium/high options; activate profile and verify `agent.variant` in opencode config

## Checklist

- [x] I linked an issue
- [x] I kept the change as small and focused as possible
- [x] I explained the scope if the diff is broader than usual
- [x] I included validation notes