### PR TITLE
fix(profiles): tolerate BOM in JSON reads

### DIFF
--- a/src/profiles.test.ts
+++ b/src/profiles.test.ts
@@ -2132,6 +2132,43 @@ describe('profiles logic', () => {
       });
     });
 
+    it('activates profiles when the profile JSON has a leading UTF-8 BOM', async () => {
+      vi.mocked(fs.existsSync).mockImplementation((filePath: any) => String(filePath) === '/mock/config/opencode.json');
+      vi.mocked(fs.readFileSync).mockImplementation((filePath: any) => {
+        if (String(filePath) === '/mock/profiles/team.json') {
+          return `\uFEFF${JSON.stringify({ models: { 'sdd-init': 'gpt-4' } })}`;
+        }
+
+        return JSON.stringify({
+          agent: { 'sdd-init': { model: 'old/model' } },
+        });
+      });
+
+      const update = vi.fn().mockResolvedValue({ data: {} });
+      const api = {
+        ui: { toast: vi.fn() },
+        client: {
+          global: {
+            config: {
+              get: vi.fn(),
+              update,
+            },
+          },
+        },
+      } as any;
+
+      const result = await activateProfileFile(api, '/mock/profiles/team.json', 'team');
+
+      expect(result?.agent['sdd-init']?.model).toBe('gpt-4');
+      expect(update).toHaveBeenCalledWith({
+        config: expect.objectContaining({
+          agent: expect.objectContaining({
+            'sdd-init': expect.objectContaining({ model: 'gpt-4' }),
+          }),
+        }),
+      });
+    });
+
     it('shows sanitized config validation details when config update fails', async () => {
       vi.mocked(fs.existsSync).mockImplementation((filePath: any) => String(filePath) === '/mock/config/opencode.json');
       vi.mocked(fs.readFileSync).mockImplementation((filePath: any) => {

--- a/src/profiles.test.ts
+++ b/src/profiles.test.ts
@@ -129,6 +129,17 @@ describe('profiles logic', () => {
       expect(models).toEqual({ 'sdd-init': 'gpt-4' });
     });
 
+    it('should parse profile json with a leading UTF-8 BOM', () => {
+      const mockContent = `\uFEFF${JSON.stringify({
+        models: { 'sdd-init': 'gpt-4' },
+      })}`;
+      vi.mocked(fs.readFileSync).mockReturnValue(mockContent);
+
+      const models = readProfileModels('/mock/profiles/bom.json');
+
+      expect(models).toEqual({ 'sdd-init': 'gpt-4' });
+    });
+
     it('should parse legacy flat format', () => {
       const mockContent = JSON.stringify({
         'sdd-init': 'gpt-4',
@@ -2082,6 +2093,43 @@ describe('profiles logic', () => {
         title: 'Activation Failed',
         variant: 'error',
       }));
+    });
+
+    it('activates profiles when on-disk global config has a leading UTF-8 BOM', async () => {
+      vi.mocked(fs.existsSync).mockImplementation((filePath: any) => String(filePath) === '/mock/config/opencode.json');
+      vi.mocked(fs.readFileSync).mockImplementation((filePath: any) => {
+        if (String(filePath) === '/mock/profiles/team.json') {
+          return JSON.stringify({ models: { 'sdd-init': 'gpt-4' } });
+        }
+
+        return `\uFEFF${JSON.stringify({
+          agent: { 'sdd-init': { model: 'old/model' } },
+        })}`;
+      });
+
+      const update = vi.fn().mockResolvedValue({ data: {} });
+      const api = {
+        ui: { toast: vi.fn() },
+        client: {
+          global: {
+            config: {
+              get: vi.fn(),
+              update,
+            },
+          },
+        },
+      } as any;
+
+      const result = await activateProfileFile(api, '/mock/profiles/team.json', 'team');
+
+      expect(result?.agent['sdd-init']?.model).toBe('gpt-4');
+      expect(update).toHaveBeenCalledWith({
+        config: expect.objectContaining({
+          agent: expect.objectContaining({
+            'sdd-init': expect.objectContaining({ model: 'gpt-4' }),
+          }),
+        }),
+      });
     });
 
     it('shows sanitized config validation details when config update fails', async () => {

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -63,6 +63,10 @@ function safeString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
+function stripJsonBom(raw: string): string {
+  return raw.replace(/^\uFEFF/, "");
+}
+
 function formatIssuePath(pathValue: unknown): string | undefined {
   if (Array.isArray(pathValue)) {
     const parts = pathValue.map((part) => String(part).trim()).filter(Boolean);
@@ -238,7 +242,7 @@ function normalizePersistedProfileData(profile: ProfileData, policy?: Orchestrat
 export function readProfileModels(profilePath: string): ProfileModels {
   let raw: any;
   try {
-    raw = JSON.parse(fs.readFileSync(profilePath, "utf-8"));
+    raw = JSON.parse(stripJsonBom(fs.readFileSync(profilePath, "utf-8")));
   } catch (e) {
     if (hasErrorCode(e, "ENOENT")) {
       log.debug(`readProfileModels: file does not exist ${profilePath}`);
@@ -280,7 +284,7 @@ export function readProfileModels(profilePath: string): ProfileModels {
  */
 export function readProfileFallbackModels(profilePath: string): ProfileFallbackModels {
   try {
-    const raw = JSON.parse(fs.readFileSync(profilePath, "utf-8"));
+    const raw = JSON.parse(stripJsonBom(fs.readFileSync(profilePath, "utf-8")));
     return extractSddFallbackModels(raw);
   } catch (e) {
     if (hasErrorCode(e, "ENOENT")) {
@@ -297,7 +301,7 @@ export function readProfileFallbackModels(profilePath: string): ProfileFallbackM
  */
 export function readProfileData(profilePath: string): ProfileData {
   try {
-    const rawContent = fs.readFileSync(profilePath, "utf-8").toString();
+    const rawContent = stripJsonBom(fs.readFileSync(profilePath, "utf-8").toString());
     return readProfileDataFromRaw(rawContent);
   } catch (e) {
     if (hasErrorCode(e, "ENOENT")) {
@@ -312,7 +316,7 @@ export function readProfileData(profilePath: string): ProfileData {
 function readProfileDataFromRaw(rawContent: string): ProfileData {
   let raw: any;
   try {
-    raw = JSON.parse(rawContent);
+    raw = JSON.parse(stripJsonBom(rawContent));
   } catch (e) {
     log.warn("readProfileDataFromRaw: failed to parse raw profile JSON", e);
     return { models: {} };
@@ -1199,7 +1203,7 @@ export async function activateProfileFile(api: any, profilePath: string, profile
     let currentConfig: any;
     if (fs.existsSync(configPath)) {
       try {
-        currentConfig = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+        currentConfig = JSON.parse(stripJsonBom(fs.readFileSync(configPath, "utf-8")));
       } catch (e) {
         log.error(`activateProfileFile: failed to parse global config ${configPath}`, e);
         throw new Error("Global config JSON is invalid");


### PR DESCRIPTION
## Summary

- Strip a leading UTF-8 BOM before parsing profile JSON payloads.
- Strip a leading UTF-8 BOM before parsing the on-disk opencode global config during profile activation.
- Add regression coverage for BOM-prefixed profile JSON and global config JSON.

## Linked Issue

Closes #39

## Scope Justification

This is the minimum focused fix: it only normalizes user-managed JSON text immediately before `JSON.parse`, preserving existing behavior for invalid JSON and all non-BOM payloads.

## Validation

- Tests run: `npm test -- src/profiles.test.ts -t "UTF-8 BOM"`
- Tests run: `npm run typecheck`
- Manual verification: reproduced locally with a BOM-prefixed `~/.config/opencode/opencode.json`; after stripping/patching, profile JSON and global config parse successfully.

Note: `npm test -- src/profiles.test.ts` currently has unrelated Windows path separator failures in existing tests that compare POSIX-style `/mock/...` paths against `path.join` output on Windows. The new BOM tests pass.

## Checklist

- [x] I linked an issue
- [x] I kept the change as small and focused as possible
- [x] I explained the scope if the diff is broader than usual
- [x] I included validation notes
