### PR TITLE
feat: support Judgment Day agents in SDD Manager plugin

### DIFF
--- a/scripts/run-examples.ts
+++ b/scripts/run-examples.ts
@@ -98,8 +98,10 @@ function testExternalPromptInjection(repoRoot: string, tempDir: string): TestRes
   }
 }
 
+const MANAGED_SDD_AGENT_EXCEPTIONS = new Set(["gentle-orchestrator", "jd-judge-a", "jd-judge-b", "jd-fix-agent"]);
+
 function isManagedSddAgent(name: string): boolean {
-  return name.startsWith("sdd-");
+  return name.startsWith("sdd-") || MANAGED_SDD_AGENT_EXCEPTIONS.has(name);
 }
 
 function isFallbackEligibleSddAgent(name: string): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,7 @@ import { createLogger } from "./logger";
 
 const log = createLogger("utils");
 
-const MANAGED_SDD_AGENT_EXCEPTIONS = new Set(["gentle-orchestrator"]);
+const MANAGED_SDD_AGENT_EXCEPTIONS = new Set(["gentle-orchestrator", "jd-judge-a", "jd-judge-b", "jd-fix-agent"]);
 const FALLBACK_INELIGIBLE_AGENTS = new Set(["sdd-orchestrator", "gentle-orchestrator"]);
 
 /**


### PR DESCRIPTION
Added `jd-judge-a`, `jd-judge-b`, and `jd-fix-agent` to `MANAGED_SDD_AGENT_EXCEPTIONS` so that they appear in the TUI lists alongside other SDD profiles.